### PR TITLE
DCAC-71: Get document private URI from document API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,7 @@
         <!-- Structured logging -->
         <structured-logging.version>1.9.20</structured-logging.version>
 
-        <!-- TODO DCAC-71 > 1.0.6 -->
-        <api-sdk-manager-java-library.version>unversioned</api-sdk-manager-java-library.version>
+        <api-sdk-manager-java-library.version>1.0.7</api-sdk-manager-java-library.version>
 
         <spring-cloud-contract-wiremock.version>2.2.2.RELEASE</spring-cloud-contract-wiremock.version>
         <!-- system-rules: 1.17.2 is the latest version that works with JUnit 5.

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,8 @@
         <!-- Structured logging -->
         <structured-logging.version>1.9.20</structured-logging.version>
 
-        <!-- TODO DCAC-71 > 4.3.28 -->
-        <api-sdk-java.version>unversioned</api-sdk-java.version>
-        <api-sdk-manager-java-library.version>1.0.6</api-sdk-manager-java-library.version>
+        <!-- TODO DCAC-71 > 1.0.6 -->
+        <api-sdk-manager-java-library.version>unversioned</api-sdk-manager-java-library.version>
 
         <spring-cloud-contract-wiremock.version>2.2.2.RELEASE</spring-cloud-contract-wiremock.version>
         <!-- system-rules: 1.17.2 is the latest version that works with JUnit 5.
@@ -91,11 +90,6 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-manager-java-library</artifactId>
             <version>${api-sdk-manager-java-library.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>api-sdk-java</artifactId>
-            <version>${api-sdk-java.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <structured-logging.version>1.9.22</structured-logging.version>
 
         <api-sdk-manager-java-library.version>1.0.7</api-sdk-manager-java-library.version>
+        <re2j.version>1.7</re2j.version>
 
         <spring-cloud-contract-wiremock.version>2.2.2.RELEASE</spring-cloud-contract-wiremock.version>
         <!-- system-rules: 1.17.2 is the latest version that works with JUnit 5.
@@ -89,6 +90,11 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-manager-java-library</artifactId>
             <version>${api-sdk-manager-java-library.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.re2j</groupId>
+            <artifactId>re2j</artifactId>
+            <version>${re2j.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
 
         <!-- TODO DCAC-71 > 4.3.28 -->
         <api-sdk-java.version>unversioned</api-sdk-java.version>
-        <!-- TODO DCAC-71 > 2.0.254 -->
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.6</api-sdk-manager-java-library.version>
 
         <spring-cloud-contract-wiremock.version>2.2.2.RELEASE</spring-cloud-contract-wiremock.version>
@@ -88,11 +86,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>uk.gov.companieshouse</groupId>
-            <artifactId>private-api-sdk-java</artifactId>
-            <version>${private-api-sdk-java.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
         <!-- log4j -->
         <log4j.version>2.19.0</log4j.version>
 
+        <!-- TODO DCAC-71 > 1.9.20 -->
         <!-- Structured logging -->
-        <structured-logging.version>1.9.20</structured-logging.version>
+        <structured-logging.version>unversioned</structured-logging.version>
 
         <api-sdk-manager-java-library.version>1.0.7</api-sdk-manager-java-library.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,10 @@
         <!-- Structured logging -->
         <structured-logging.version>1.9.20</structured-logging.version>
 
-        <api-sdk-java.version>4.3.28</api-sdk-java.version>
+        <!-- TODO DCAC-71 > 4.3.28 -->
+        <api-sdk-java.version>unversioned</api-sdk-java.version>
+        <!-- TODO DCAC-71 > 2.0.254 -->
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.6</api-sdk-manager-java-library.version>
 
         <spring-cloud-contract-wiremock.version>2.2.2.RELEASE</spring-cloud-contract-wiremock.version>
@@ -85,6 +88,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,8 @@
         <!-- log4j -->
         <log4j.version>2.19.0</log4j.version>
 
-        <!-- TODO DCAC-71 > 1.9.20 -->
         <!-- Structured logging -->
-        <structured-logging.version>unversioned</structured-logging.version>
+        <structured-logging.version>1.9.22</structured-logging.version>
 
         <api-sdk-manager-java-library.version>1.0.7</api-sdk-manager-java-library.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
              See https://github.com/stefanbirkner/system-rules/issues/70 -->
         <system-rules.version>1.17.2</system-rules.version>
         <mockito-core.version>5.3.1</mockito-core.version>
+        <software.amazon.awssdk.version>2.19.14</software.amazon.awssdk.version>
     </properties>
 
     <dependencyManagement>
@@ -62,6 +63,14 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
                 <version>${log4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${software.amazon.awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -109,6 +118,16 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/ApplicationConfiguration.java
@@ -1,7 +1,11 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.config;
 
+import org.apache.http.impl.client.HttpClients;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -13,6 +17,14 @@ public class ApplicationConfiguration {
     @Bean
     Logger getLogger() {
         return LoggerFactory.getLogger(NAMESPACE);
+    }
+
+    // TODO DCAC-71 Use SDK
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        final var httpClient = HttpClients.custom().disableRedirectHandling().build();
+        final var requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+        return builder.requestFactory(() -> requestFactory).build();
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/ApplicationConfiguration.java
@@ -1,11 +1,7 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.config;
 
-import org.apache.http.impl.client.HttpClients;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.RestTemplate;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -17,14 +13,6 @@ public class ApplicationConfiguration {
     @Bean
     Logger getLogger() {
         return LoggerFactory.getLogger(NAMESPACE);
-    }
-
-    // TODO DCAC-71 Use SDK
-    @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        final var httpClient = HttpClients.custom().disableRedirectHandling().build();
-        final var requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
-        return builder.requestFactory(() -> requestFactory).build();
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter;
+
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Component
+public class PublicToPrivateUriConverter {
+
+    private static final String S3_SCHEME_PREFIX = "s3://";
+
+    public URI convertToPrivateUri(final URI publicUri) throws URISyntaxException {
+        // TODO DCAC-71 Error handling
+        final var hostName = publicUri.getHost().split("\\.")[0];
+        final var documentKey = publicUri.getPath();
+        final var bucketUri = S3_SCHEME_PREFIX + hostName;
+
+        return new URI(bucketUri + documentKey);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter;
 
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.UriConversionException;
 import uk.gov.companieshouse.logging.Logger;
@@ -8,8 +10,6 @@ import uk.gov.companieshouse.logging.util.DataMap;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Component
 public class PublicToPrivateUriConverter {

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
@@ -17,7 +17,7 @@ public class PublicToPrivateUriConverter {
     private final Logger logger;
 
     private static final Pattern PUBLIC_URI_PATTERN =
-            Pattern.compile("^https:\\/\\/.*\\.s3\\.eu-west-2\\.amazonaws\\.com\\/(.*?pdf)");
+            Pattern.compile("^https://.*\\.s3\\.eu-west-2\\.amazonaws\\.com/(.*?pdf)");
     private static final String S3_SCHEME_PREFIX = "s3://";
 
     public PublicToPrivateUriConverter(Logger logger) {

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter;
 
-import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.UriConversionException;
@@ -51,7 +50,7 @@ public class PublicToPrivateUriConverter {
     }
 
     private boolean isValidPublicUri(final URI publicUri) {
-        final Matcher matcher = PUBLIC_URI_PATTERN.matcher(publicUri.toString());
+        final var matcher = PUBLIC_URI_PATTERN.matcher(publicUri.toString());
         return matcher.find();
     }
 

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverter.java
@@ -3,9 +3,11 @@ package uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.UriConversionException;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.util.DataMap;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -24,9 +26,8 @@ public class PublicToPrivateUriConverter {
 
     public URI convertToPrivateUri(final URI publicUri) {
         if (!isValidPublicUri(publicUri)) {
-            // TODO DCAC-71 Structured logging
             final String error = "Invalid public URI: " + publicUri;
-            logger.error(error);
+            logger.error(error, getLogMap(publicUri));
             throw new UriConversionException(error);
         }
 
@@ -37,11 +38,10 @@ public class PublicToPrivateUriConverter {
         try {
             return createURI(bucketUri, documentKey);
         } catch (URISyntaxException ex) {
-            // TODO DCAC-71 Structured logging
             final String error = "Caught URISyntaxException creating private URI from `" +
                     bucketUri  + "' and '" + documentKey + "', derived from public URI '" + publicUri +
                     "`, error message is '" + ex.getMessage() + "'";
-            logger.error(error);
+            logger.error(error, getLogMap(publicUri));
             throw new UriConversionException(error, ex);
         }
     }
@@ -53,5 +53,12 @@ public class PublicToPrivateUriConverter {
     private boolean isValidPublicUri(final URI publicUri) {
         final Matcher matcher = PUBLIC_URI_PATTERN.matcher(publicUri.toString());
         return matcher.find();
+    }
+
+    private Map<String, Object> getLogMap(final URI publicUri) {
+        return new DataMap.Builder()
+                .documentPublicUri(publicUri.toString())
+                .build()
+                .getLogMap();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesChecker.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesChecker.java
@@ -15,7 +15,8 @@ public class EnvironmentVariablesChecker {
     public enum RequiredEnvironmentVariables {
         API_URL("API_URL"),
         PAYMENTS_API_URL("PAYMENTS_API_URL"),
-        CHS_API_KEY("CHS_API_KEY");
+        CHS_API_KEY("CHS_API_KEY"),
+        DOCUMENT_API_LOCAL_URL("DOCUMENT_API_LOCAL_URL");
 
         private final String name;
 

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/exception/NonRetryableException.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/exception/NonRetryableException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception;
+
+/**
+ * An unrecoverable error has occurred, e.g. due to the service being misconfigured or due to invalid data.
+ */
+public class NonRetryableException extends RuntimeException {
+
+    public NonRetryableException(String message) {
+        super(message);
+    }
+
+    public NonRetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/exception/RetryableException.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/exception/RetryableException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception;
+
+/**
+ * A recoverable exception has occurred e.g. due to a service that is temporarily unavailable.
+ */
+public class RetryableException extends RuntimeException {
+
+    public RetryableException(String message) {
+        super(message);
+    }
+
+    public RetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/exception/UriConversionException.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/exception/UriConversionException.java
@@ -4,7 +4,7 @@ package uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception;
  * Wraps and propagates exceptions originating in the
  * {@link uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter}.
  */
-public class UriConversionException extends RuntimeException {
+public class UriConversionException extends NonRetryableException {
     public UriConversionException(String message) {
         super(message);
     }

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/exception/UriConversionException.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/exception/UriConversionException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception;
+
+/**
+ * Wraps and propagates exceptions originating in the
+ * {@link uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter}.
+ */
+public class UriConversionException extends RuntimeException {
+    public UriConversionException(String message) {
+        super(message);
+    }
+
+    public UriConversionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/ApiClientService.java
@@ -1,11 +1,16 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
 
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 @Service
 public class ApiClientService {
+
+    public ApiClient getApiClient() {
+        return ApiSdkManager.getSDK();
+    }
 
     public InternalApiClient getInternalApiClient() {
         return ApiSdkManager.getPrivateSDK();

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
@@ -1,0 +1,66 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriTemplate;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import static java.lang.System.getenv;
+
+@Service
+public class DocumentService {
+
+    private static final UriTemplate GET_SHORT_LIVED_DOCUMENT_URL = new UriTemplate("/{documentMetadata}/content");
+
+    private final RestTemplate restTemplate;
+
+    private final Logger logger;
+
+    private final PublicToPrivateUriConverter converter;
+
+    public DocumentService(RestTemplate restTemplate, Logger logger, PublicToPrivateUriConverter converter) {
+        this.restTemplate = restTemplate;
+        this.logger = logger;
+        this.converter = converter;
+    }
+
+    public URI getPrivateUri(final String documentMetadata) throws URISyntaxException {
+        final URI publicUri = getPublicUri(documentMetadata);
+        return converter.convertToPrivateUri(publicUri);
+    }
+
+    // TODO DCAC-71 Use SDK rather than Spring.
+    public URI getPublicUri(final String documentMetadata) {
+        final String uri = GET_SHORT_LIVED_DOCUMENT_URL.expand(documentMetadata).toString();
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(getBasicAuthCredentials());
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_PDF));
+        final HttpEntity<String> httpEntity = new HttpEntity<>(null, headers);
+
+        // TODO DCAC-71 Configure doc api domain
+        // TODO DCAC-71 Structured logging
+        final var message =
+                restTemplate.exchange(
+                        "http://document-api-cidev.aws.chdev.org" + uri,
+                        HttpMethod.GET,
+                        httpEntity,
+                        HttpMessage.class);
+        return message.getHeaders().getLocation();
+    }
+
+    private static String getBasicAuthCredentials() {
+        // TODO DCAC-71 Constants, required env vars etc
+        return getenv("BASIC_AUTH_CREDENTIALS");
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
@@ -1,35 +1,34 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
 
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMessage;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriTemplate;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
+import java.util.List;
 
-import static java.lang.System.getenv;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Service
 public class DocumentService {
 
-    private static final UriTemplate GET_SHORT_LIVED_DOCUMENT_URL = new UriTemplate("/{documentMetadata}/content");
+    private static final UriTemplate GET_SHORT_LIVED_DOCUMENT_URL = new UriTemplate("{documentMetadata}/content");
 
-    private final RestTemplate restTemplate;
+    private final ApiClientService apiClientService;
 
     private final Logger logger;
 
     private final PublicToPrivateUriConverter converter;
 
-    public DocumentService(RestTemplate restTemplate, Logger logger, PublicToPrivateUriConverter converter) {
-        this.restTemplate = restTemplate;
+    public DocumentService(ApiClientService apiClientService, Logger logger, PublicToPrivateUriConverter converter) {
+        this.apiClientService = apiClientService;
         this.logger = logger;
         this.converter = converter;
     }
@@ -39,28 +38,36 @@ public class DocumentService {
         return converter.convertToPrivateUri(publicUri);
     }
 
-    // TODO DCAC-71 Use SDK rather than Spring.
     public URI getPublicUri(final String documentMetadata) {
         final String uri = GET_SHORT_LIVED_DOCUMENT_URL.expand(documentMetadata).toString();
-        final HttpHeaders headers = new HttpHeaders();
-        headers.setBasicAuth(getBasicAuthCredentials());
-        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_PDF));
-        final HttpEntity<String> httpEntity = new HttpEntity<>(null, headers);
-
-        // TODO DCAC-71 Configure doc api domain
-        // TODO DCAC-71 Structured logging
-        final var message =
-                restTemplate.exchange(
-                        "http://document-api-cidev.aws.chdev.org" + uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        HttpMessage.class);
-        return message.getHeaders().getLocation();
+        final InternalApiClient apiClient = getInternalApiClient();
+        try {
+             final var headers = apiClient.privateDocumentResourceHandler().getDocument(uri).execute().getHeaders();
+            // TODO DCAC-71 Error handling
+            final var locations = (List<String>) headers.get(HttpHeaders.LOCATION.toLowerCase());
+            return new URI(locations.get(0));
+        } catch (ApiErrorResponseException ex) {
+            // TODO DCAC-71 Structured logging, error handling
+            // throw getResponseStatusException(ex, apiClient, companyNumber, filingHistoryDocumentId, uri);
+            logger.error("Caught ApiErrorResponseException getting public URI.", ex);
+            throw new RuntimeException(ex);
+        } catch (URIValidationException | URISyntaxException ex) {
+            // Should this happen (unlikely), it is a broken contract, hence 500.
+            final String error = "Invalid URI " + uri + " to get document public URI.";
+            // TODO DCAC-71 Structured logging
+            // logger.error(error, ex, getLogMap(companyNumber, filingHistoryDocumentId, INTERNAL_SERVER_ERROR, error));
+            logger.error(error, ex);
+            throw new ResponseStatusException(INTERNAL_SERVER_ERROR, error);
+        }
     }
 
-    private static String getBasicAuthCredentials() {
-        // TODO DCAC-71 Constants, required env vars etc
-        return getenv("BASIC_AUTH_CREDENTIALS");
+    private InternalApiClient getInternalApiClient() {
+        try {
+            return apiClientService.getInternalApiClient();
+        } catch (RuntimeException re) {
+            logger.error("Caught RuntimeException getting API client: " + re.getMessage());
+            throw re;
+        }
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
@@ -42,7 +42,7 @@ public class DocumentService {
         final String uri = GET_SHORT_LIVED_DOCUMENT_URL.expand(documentMetadata).toString();
         final ApiClient apiClient = getApiClient();
         try {
-             final var headers = apiClient.privateDocumentResourceHandler().getDocument(uri).execute().getHeaders();
+             final var headers = apiClient.document().getDocument(uri).execute().getHeaders();
             // TODO DCAC-71 Error handling
             final var locations = (List<String>) headers.get(HttpHeaders.LOCATION.toLowerCase());
             return new URI(locations.get(0));

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
@@ -16,7 +16,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.MOVED_TEMPORARILY;
+import static org.springframework.http.HttpStatus.FOUND;
 
 @Service
 public class DocumentService {
@@ -69,7 +69,7 @@ public class DocumentService {
     private ApiResponse<Void> getDocumentContent(final String uri)
             throws ApiErrorResponseException, URIValidationException {
         final ApiResponse<Void> response = getApiClient().document().getDocument(uri).execute();
-        if (response.getStatusCode() != MOVED_TEMPORARILY.value()) {
+        if (response.getStatusCode() != FOUND.value()) {
             // TODO DCAC-71 Structured logging
             final String error = "Received unexpected response status code " +
                     response.getStatusCode() +

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriTemplate;
-import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
@@ -40,7 +40,7 @@ public class DocumentService {
 
     public URI getPublicUri(final String documentMetadata) {
         final String uri = GET_SHORT_LIVED_DOCUMENT_URL.expand(documentMetadata).toString();
-        final InternalApiClient apiClient = getInternalApiClient();
+        final ApiClient apiClient = getApiClient();
         try {
              final var headers = apiClient.privateDocumentResourceHandler().getDocument(uri).execute().getHeaders();
             // TODO DCAC-71 Error handling
@@ -61,9 +61,9 @@ public class DocumentService {
         }
     }
 
-    private InternalApiClient getInternalApiClient() {
+    private ApiClient getApiClient() {
         try {
-            return apiClientService.getInternalApiClient();
+            return apiClientService.getApiClient();
         } catch (RuntimeException re) {
             logger.error("Caught RuntimeException getting API client: " + re.getMessage());
             throw re;

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
@@ -51,7 +51,7 @@ public class DocumentService {
     }
 
     public URI getPublicUri(final String documentMetadata) {
-        final String uri = GET_DOCUMENT_CONTENT_URL.expand(documentMetadata).toString();
+        final var uri = GET_DOCUMENT_CONTENT_URL.expand(documentMetadata).toString();
         try {
             final var response = getDocumentContent(uri, documentMetadata);
             return getFirstLocationAsUri(response, documentMetadata);

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
@@ -35,7 +35,7 @@ public class DocumentService {
         this.converter = converter;
     }
 
-    public URI getPrivateUri(final String documentMetadata) throws URISyntaxException {
+    public URI getPrivateUri(final String documentMetadata) {
         final URI publicUri = getPublicUri(documentMetadata);
         return converter.convertToPrivateUri(publicUri);
     }

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentService.java
@@ -2,13 +2,14 @@ package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.filinghistory.FilingApi;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.NonRetryableException;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.RetryableException;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.util.DataMap;
 
@@ -46,7 +47,7 @@ public class FilingHistoryDocumentService {
             final String filingHistoryDocumentId) {
         logger.info("Getting filing history document " + filingHistoryDocumentId + " for company number "
                 + companyNumber + ".", getLogMap(companyNumber, filingHistoryDocumentId));
-        final ApiClient apiClient = getInternalApiClient();
+        final ApiClient apiClient = getInternalApiClient(companyNumber, filingHistoryDocumentId);
         final String uri = GET_FILING_HISTORY_DOCUMENT.expand(companyNumber, filingHistoryDocumentId).toString();
         try {
             final FilingApi filing = apiClient.filing().get(uri).execute().getData();
@@ -55,12 +56,12 @@ public class FilingHistoryDocumentService {
                     getLogMap(companyNumber, filingHistoryDocumentId, metadata));
             return metadata;
         } catch (ApiErrorResponseException ex) {
-            throw getResponseStatusException(ex, apiClient, companyNumber, filingHistoryDocumentId, uri);
+            throw getRetryableException(ex, apiClient, companyNumber, filingHistoryDocumentId, uri);
         } catch (URIValidationException ex) {
-            // Should this happen (unlikely), it is a broken contract, hence 500.
+            // Should this happen (unlikely), it is a programmatic error, hence not recoverable.
             final String error = "Invalid URI " + uri + " for filing";
             logger.error(error, ex, getLogMap(companyNumber, filingHistoryDocumentId, INTERNAL_SERVER_ERROR, error));
-            throw new ResponseStatusException(INTERNAL_SERVER_ERROR, error);
+            throw new NonRetryableException(error, ex);
         }
 
     }
@@ -72,35 +73,38 @@ public class FilingHistoryDocumentService {
      * @param companyNumber the number of the company for which the filing history is looked up
      * @param filingHistoryDocumentId the filing history document ID
      * @param uri the URI used to communicate with the company filing history API
-     * @return the {@link ResponseStatusException} exception to report the problem
+     * @return the {@link RetryableException} exception to report the problem
      */
-    private ResponseStatusException getResponseStatusException(final ApiErrorResponseException apiException,
-                                                               final ApiClient client,
-                                                               final String companyNumber,
-                                                               final String filingHistoryDocumentId,
-                                                               final String uri) {
-        final ResponseStatusException propagatedException;
+    private RetryableException getRetryableException(final ApiErrorResponseException apiException,
+                                                     final ApiClient client,
+                                                     final String companyNumber,
+                                                     final String filingHistoryDocumentId,
+                                                     final String uri) {
+        final RetryableException propagatedException;
         if (apiException.getStatusCode() >= INTERNAL_SERVER_ERROR.value()) {
             final String error = "Error sending request to "
                     + client.getBasePath() + uri + ": " + apiException.getStatusMessage();
             logger.error(error, apiException,
                     getLogMap(companyNumber, filingHistoryDocumentId, INTERNAL_SERVER_ERROR, error));
-            propagatedException = new ResponseStatusException(INTERNAL_SERVER_ERROR, error);
+            propagatedException = new RetryableException(error);
         } else {
             final String error = "Error getting filing history document " + filingHistoryDocumentId +
                     " for company number " + companyNumber + ".";
             logger.error(error, apiException, getLogMap(companyNumber, filingHistoryDocumentId, BAD_REQUEST, error));
-            propagatedException =  new ResponseStatusException(BAD_REQUEST, error);
+            propagatedException =  new RetryableException(error);
         }
         return propagatedException;
     }
 
-    private InternalApiClient getInternalApiClient() {
+    private InternalApiClient getInternalApiClient(final String companyNumber,
+                                                   final String filingHistoryDocumentId) {
         try {
             return apiClientService.getInternalApiClient();
         } catch (RuntimeException re) {
-            logger.error("Caught RuntimeException getting API client: " + re.getMessage());
-            throw re;
+            // Should this happen (unlikely), it would likely not be a recoverable issue.
+            final var error = "Caught RuntimeException getting API client: " + re.getMessage();
+            logger.error(error, getLogMap(companyNumber, filingHistoryDocumentId));
+            throw new NonRetryableException(error, re);
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateDocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateDocumentService.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriTemplate;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import static java.lang.System.getenv;
+
+/**
+ * @Deprecated Use {@link DocumentService}.
+ */
+@Service
+public class RestTemplateDocumentService {
+
+    private static final UriTemplate GET_SHORT_LIVED_DOCUMENT_URL = new UriTemplate("{documentMetadata}/content");
+
+    private final RestTemplate restTemplate;
+
+    private final Logger logger;
+
+    private final PublicToPrivateUriConverter converter;
+
+    public RestTemplateDocumentService(RestTemplate restTemplate, Logger logger, PublicToPrivateUriConverter converter) {
+        this.restTemplate = restTemplate;
+        this.logger = logger;
+        this.converter = converter;
+    }
+
+    public URI getPrivateUri(final String documentMetadata) throws URISyntaxException {
+        final URI publicUri = getPublicUri(documentMetadata);
+        return converter.convertToPrivateUri(publicUri);
+    }
+
+    public URI getPublicUri(final String documentMetadata) {
+        final String uri = GET_SHORT_LIVED_DOCUMENT_URL.expand(documentMetadata).toString();
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(getBasicAuthCredentials());
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_PDF));
+        final HttpEntity<String> httpEntity = new HttpEntity<>(null, headers);
+
+        // TODO DCAC-71 Configure doc api domain
+        // TODO DCAC-71 Structured logging
+        final var message =
+                restTemplate.exchange(
+                        "http://document-api-cidev.aws.chdev.org" + uri,
+                        HttpMethod.GET,
+                        httpEntity,
+                        HttpMessage.class);
+        return message.getHeaders().getLocation();
+    }
+
+    private static String getBasicAuthCredentials() {
+        // TODO DCAC-71 Constants, required env vars etc
+        return getenv("BASIC_AUTH_CREDENTIALS");
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/DigitalCertifiedCopyProcessorApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/DigitalCertifiedCopyProcessorApplicationTests.java
@@ -3,8 +3,11 @@ package uk.gov.companieshouse.digitalcertifiedcopyprocessor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 
 @SpringBootTest
+@SpringJUnitConfig(TestConfig.class)
 class DigitalCertifiedCopyProcessorApplicationTests {
 
 	@SuppressWarnings("squid:S2699") // at least one assertion

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/TestConfig.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/TestConfig.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.config;
+
+import org.apache.http.impl.client.HttpClients;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@TestConfiguration
+public class TestConfig {
+
+    @Bean
+    public RestTemplateBuilder getRestTemplateBuilder() {
+        return new RestTemplateBuilder();
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        final var httpClient = HttpClients.custom().disableRedirectHandling().build();
+        final var requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+        return builder.requestFactory(() -> requestFactory).build();
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverterTest.java
@@ -1,0 +1,86 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.UriConversionException;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.EXPECTED_PRIVATE_DOCUMENT_URI;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.LOCATION;
+
+@ExtendWith(MockitoExtension.class)
+class PublicToPrivateUriConverterTest {
+
+    private static final String EXPECTED_INVALID_PRIVATE_URI_MESSAGE =
+    "Caught URISyntaxException creating private URI from `s3://document-api-images-cidev' and " +
+            "'/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf', derived from public URI '"
+            + LOCATION + "`, error message is 'Invalid URI: s3://blah'";
+
+    @InjectMocks
+    private PublicToPrivateUriConverter converterUnderTest;
+
+    @Mock
+    private Logger logger;
+
+    @Test
+    @DisplayName("convertToPrivateUri converts public URI (location) to private URI successfully")
+    void convertToPrivateUriConvertsAsExpected() throws URISyntaxException {
+
+        // Given and when
+        final URI privateUri = converterUnderTest.convertToPrivateUri(new URI(LOCATION));
+
+        // Then
+        assertThat(privateUri, is(EXPECTED_PRIVATE_DOCUMENT_URI));
+    }
+
+    @Test
+    @DisplayName("convertToPrivateUri rejects an invalid public URI")
+    void convertToPrivateUriRejectsAnInvalidUri() throws URISyntaxException {
+
+        // Given
+        final URI invalidPublicUri = new URI("localhost");
+
+        // Given, when and then
+        final UriConversionException conversionException =
+                assertThrows(UriConversionException.class,
+                            () -> converterUnderTest.convertToPrivateUri(invalidPublicUri));
+
+        // And then
+        assertThat(conversionException.getMessage(), is("Invalid public URI: localhost"));
+
+    }
+
+    @Test
+    @DisplayName("convertToPrivateUri rejects a public URI that leads to an invalid private URI")
+    void convertToPrivateUriRejectsUriLeadingToInvalidPrivateUri() throws URISyntaxException {
+
+        // Given
+        final URI validPublicUri = new URI(LOCATION);
+        final var localConverter = new PublicToPrivateUriConverter(logger) {
+            @Override
+            protected URI createURI(String bucketUri, String documentKey) throws URISyntaxException {
+                throw new URISyntaxException("s3://blah", "Invalid URI");
+            }
+        };
+
+        // When and then
+        final UriConversionException conversionException =
+                assertThrows(UriConversionException.class,
+                        () -> localConverter.convertToPrivateUri(validPublicUri));
+
+        // And then
+        assertThat(conversionException.getMessage(), is(EXPECTED_INVALID_PRIVATE_URI_MESSAGE));
+
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverterTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/converter/PublicToPrivateUriConverterTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.EXPECTED_PRIVATE_DOCUMENT_URI;
-import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.LOCATION;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.PUBLIC_DOCUMENT_URI;
 
 @ExtendWith(MockitoExtension.class)
 class PublicToPrivateUriConverterTest {
@@ -24,7 +24,7 @@ class PublicToPrivateUriConverterTest {
     private static final String EXPECTED_INVALID_PRIVATE_URI_MESSAGE =
     "Caught URISyntaxException creating private URI from `s3://document-api-images-cidev' and " +
             "'/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf', derived from public URI '"
-            + LOCATION + "`, error message is 'Invalid URI: s3://blah'";
+            + PUBLIC_DOCUMENT_URI + "`, error message is 'Invalid URI: s3://blah'";
 
     @InjectMocks
     private PublicToPrivateUriConverter converterUnderTest;
@@ -37,7 +37,7 @@ class PublicToPrivateUriConverterTest {
     void convertToPrivateUriConvertsAsExpected() throws URISyntaxException {
 
         // Given and when
-        final URI privateUri = converterUnderTest.convertToPrivateUri(new URI(LOCATION));
+        final URI privateUri = converterUnderTest.convertToPrivateUri(new URI(PUBLIC_DOCUMENT_URI));
 
         // Then
         assertThat(privateUri, is(EXPECTED_PRIVATE_DOCUMENT_URI));
@@ -65,7 +65,7 @@ class PublicToPrivateUriConverterTest {
     void convertToPrivateUriRejectsUriLeadingToInvalidPrivateUri() throws URISyntaxException {
 
         // Given
-        final URI validPublicUri = new URI(LOCATION);
+        final URI validPublicUri = new URI(PUBLIC_DOCUMENT_URI);
         final var localConverter = new PublicToPrivateUriConverter(logger) {
             @Override
             protected URI createURI(String bucketUri, String documentKey) throws URISyntaxException {

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesCheckerTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesCheckerTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.API_URL;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.CHS_API_KEY;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.DOCUMENT_API_LOCAL_URL;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.PAYMENTS_API_URL;
 
 @SpringBootTest
@@ -53,7 +54,7 @@ class EnvironmentVariablesCheckerTest {
 
     @DisplayName("returns false if PAYMENTS_API_URL is missing")
     @Test
-    void checkEnvironmentVariablesAllPresentReturnsFalseIfPaymentsApiUrlIdMissing() {
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfPaymentsApiUrlMissing() {
         populateAllVariablesExceptOneAndAssertSomethingMissing(PAYMENTS_API_URL);
     }
 
@@ -61,6 +62,12 @@ class EnvironmentVariablesCheckerTest {
     @Test
     void checkEnvironmentVariablesAllPresentReturnsFalseIfChsApiKeyMissing() {
         populateAllVariablesExceptOneAndAssertSomethingMissing(CHS_API_KEY);
+    }
+
+    @DisplayName("returns false if DOCUMENT_API_LOCAL_URL is missing")
+    @Test
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfDocumentApiLocalUrlMissing() {
+        populateAllVariablesExceptOneAndAssertSomethingMissing(DOCUMENT_API_LOCAL_URL);
     }
 
     private void populateAllVariablesExceptOneAndAssertSomethingMissing(

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesCheckerTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesCheckerTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 
 import java.util.Arrays;
 
@@ -18,6 +20,7 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.En
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.PAYMENTS_API_URL;
 
 @SpringBootTest
+@SpringJUnitConfig(TestConfig.class)
 class EnvironmentVariablesCheckerTest {
 
     private static final String TOKEN_VALUE = "token value";

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceIntegrationTest.java
@@ -1,0 +1,180 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import org.hamcrest.core.Is;
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.givenThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.serviceUnavailable;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils.givenSdkIsConfigured;
+
+/**
+ * Integration tests the {@link DocumentService}.
+ */
+@SpringBootTest
+@SpringJUnitConfig(classes={
+        ApplicationConfiguration.class,
+        DocumentServiceIntegrationTest.Config.class,
+        TestConfig.class})
+@AutoConfigureWireMock(port = 0)
+class DocumentServiceIntegrationTest {
+
+    @Rule
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    private static final String DOCUMENT_METADATA = "/document/specimen";
+
+    private static final String LOCATION =
+        "https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/" +
+        "docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf" +
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+        "&X-Amz-Credential=AWS_Access_Key_ID%2F20230523%2Feu-west-2%2Fs3%2Faws4_request" +
+        "&X-Amz-Date=20230523T071124Z" +
+        "&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEKf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2" +
+        "FwEaCWV1LXdlc3QtMiJIMEYCIQCkH0CgdgxtZUHzWSGqGZfvhArMBVhjUipfyzC7HqxybwIhAO3%2FACQh8hYR" +
+        "P9tBbyeKNThXR5x4t%2B4kWBWFM9o4pYhjKsUFCND%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQABoMMTY5OTQy" +
+        "MDIwNTIxIgy%2FRjW4UMixpIgXLyoqmQUlJi%2FBNQsLmcvzHsmKLGAkTSa%2B07rB3JADObNlS1F8ajKNef%2" +
+        "BHlGPmGtWr4TDVo%2BmfASgChgdwaZfZQ5%2BedFmO1O5mZIaaTXKpnpnggPEVv8EzFF4%2BuASmFhhD5GVEXi" +
+        "MHdMqXaYzeKpry2wjJFvvcUhLpwOq9MdGEOd9rJOWp3EwX35u6geuFlR36yHPqXZD8gEmOltWJXz64G8otbmxo" +
+        "imy9ZMjUe%2FT8KbAEg7WUfpHo23022myZjeUJYfk2X32mwQ%2F8FsUoU2pMQpTUHO0QmBlscMKzqlJMHalBzE" +
+        "ut%2Fuiw0jl%2BbbXmRcz6piW4DTHuK%2BQsRUNGAjItwaFxVjNemJ14m1yDSNEaRE1JdqWutAsdKQ87XgV%2F" +
+        "s9Td8KeFLJH%2FaC86ZXsgEjB2esnjp0q56ATBCs7yp9Im1966%2BoBOZaxqNAbtLwr%2F11YKn5V01R9uQpPi" +
+        "ieEKp7nipRbxajBB6bJcTen%2By6dvxGm%2FladwvUIH7BRWYPDCx1DA9s1bUEKpLg%2F2FSVEmhq6yjZV%2Bu" +
+        "eNkOBwqKwcLYKWgB3nfVYEu1ORzx6IMbVksnMJ%2BAlHrfj9HJF3XYDxca8yw%2F%2BIvi4oSK3j2Bc2bRyHim" +
+        "q9UCdkiQFFnyPzplZ8OVkZ0%2FfOnv0LkPYhkdiMUoPWIqPcOyjmSNjF%2FbqOs2O7cN8xUUy4Nv%2FhzUYaYZ" +
+        "svV6cy3Gk7DEq5Uj8eT5fEd3zlwLg0YKaG%2BEs2pHdoEIrDx6SgRDmZF5%2FlKwIEG8HrvkFLBvXxEjSnr%2F" +
+        "u0naENzYXIg9fgtc%2BtctfbNtD1jloLe0RelNMGWhP9huPN1kotv3AnJQ%2B4TCxhIbDQeJBox%2BpR7sSfso" +
+        "UfCAAgZr8ZzBlkhqAxYbAOCz3jhCPlLRdaGzD8v7GjBjqwAev5qyBqHCbUewXjxQs0JEOegwMO4gQ7IJt7OU0m" +
+        "l1%2F3gogILJ2hpX6SvPCIT5ECm0NR9gaO2Ej%2B1RSflO%2FwBMpo2p48rwUVnUZ2LwNnvGxf79BwbyMJ%2Bd" +
+        "cgaHQks4z5suSYJ4fabfQnYV32CwzEc%2FdNxaPKM7TFzaqaU%2FiVB91yVncr9sMp%2B8zKVMSyFBB32bQPYL" +
+        "7qZT33foMHOrQP3BCQjovrlGe67hOKURrh5lkf" +
+        "&X-Amz-SignedHeaders=host" +
+        "&response-content-disposition=inline%3Bfilename%3D%22companies_house_document.pdf%22" +
+        "&X-Amz-Signature=e18b2345566e0340bfc6ca7633939039df9fb71c1a44265701bb7102e42094c0";
+
+    private static final URI EXPECTED_PRIVATE_DOCUMENT_URI;
+    static {
+        try {
+            EXPECTED_PRIVATE_DOCUMENT_URI = new URI(
+                "s3://document-api-images-cidev/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf");
+        } catch (URISyntaxException e) {
+            // This will not happen.
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Autowired
+    private DocumentService serviceUnderTest;
+
+    @Autowired
+    private Environment environment;
+
+    @Configuration
+    @ComponentScan(basePackageClasses = DocumentServiceIntegrationTest.class)
+    static class Config { }
+
+    @Test
+    @DisplayName("getPrivateUri() gets the document private URI successfully")
+    void getPrivateUriGetsUriSuccessfully() throws  URISyntaxException {
+
+        // Given
+        givenSdkIsConfigured(environment, environmentVariables);
+        givenThat(get(urlEqualTo( DOCUMENT_METADATA + "/content"))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", LOCATION)));
+
+        // When
+        final URI privateUri =
+                serviceUnderTest.getPrivateUri(DOCUMENT_METADATA);
+
+        // Then
+        assertThat(privateUri, is(EXPECTED_PRIVATE_DOCUMENT_URI));
+    }
+
+    @Test
+    @DisplayName("getPrivateUri() throws 500 Internal Server Error for unknown document")
+    void getPrivateUriThrowsInternalServerErrorForUnknownDocument() {
+
+        // Given
+        givenSdkIsConfigured(environment, environmentVariables);
+        givenThat(get(urlEqualTo( DOCUMENT_METADATA + "/content"))
+                .willReturn(notFound()));
+
+        // When and then
+        assertDocumentApiRequestIssuePropagated(NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getPrivateUri() throws 500 Internal Server Error for service unavailable")
+    void getPrivateUriThrowsInternalServerErrorForServiceUnavailable() {
+
+        // Given
+        givenSdkIsConfigured(environment, environmentVariables);
+        givenThat(get(urlEqualTo( DOCUMENT_METADATA + "/content"))
+                .willReturn(serviceUnavailable()));
+
+        // When and then
+        assertDocumentApiRequestIssuePropagated(SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    @DisplayName("getPrivateUri() throws 500 Internal Server Error for connection reset")
+    void getPrivateUriThrowsInternalServerErrorForConnectionReset() {
+
+        // Given
+        givenSdkIsConfigured(environment, environmentVariables);
+        givenThat(get(urlEqualTo( DOCUMENT_METADATA + "/content"))
+                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+        // When and then
+        final ResponseStatusException exception =
+                Assertions.assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getPrivateUri(DOCUMENT_METADATA));
+        assertThat(exception.getStatus(), Is.is(INTERNAL_SERVER_ERROR));
+        final String expectedReason =
+                "Caught ApiErrorResponseException with status 500, and message 'null' getting public URI using " +
+                        "document content request " + DOCUMENT_METADATA + "/content.";
+        assertThat(exception.getReason(), Is.is(expectedReason));
+    }
+
+    private void assertDocumentApiRequestIssuePropagated(final HttpStatus underlyingStatus) {
+        final ResponseStatusException exception =
+                Assertions.assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getPrivateUri(DOCUMENT_METADATA));
+        assertThat(exception.getStatus(), Is.is(INTERNAL_SERVER_ERROR));
+        final String expectedReason =
+                "Received unexpected response status code " +
+                        underlyingStatus.value() + " getting public URI using document content request "
+                        + DOCUMENT_METADATA + "/content.";
+        assertThat(exception.getReason(), Is.is(expectedReason));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceIntegrationTest.java
@@ -16,7 +16,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.web.server.ResponseStatusException;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 
 import java.net.URI;
@@ -33,16 +32,14 @@ import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.LOCATION;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils.givenSdkIsConfigured;
 
 /**
  * Integration tests the {@link DocumentService}.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes={
-        ApplicationConfiguration.class,
-        DocumentServiceIntegrationTest.Config.class,
-        TestConfig.class})
+@SpringJUnitConfig(classes={DocumentServiceIntegrationTest.Config.class, TestConfig.class})
 @AutoConfigureWireMock(port = 0)
 class DocumentServiceIntegrationTest {
 
@@ -50,34 +47,6 @@ class DocumentServiceIntegrationTest {
     public EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     private static final String DOCUMENT_METADATA = "/document/specimen";
-
-    private static final String LOCATION =
-        "https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/" +
-        "docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf" +
-        "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
-        "&X-Amz-Credential=AWS_Access_Key_ID%2F20230523%2Feu-west-2%2Fs3%2Faws4_request" +
-        "&X-Amz-Date=20230523T071124Z" +
-        "&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEKf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2" +
-        "FwEaCWV1LXdlc3QtMiJIMEYCIQCkH0CgdgxtZUHzWSGqGZfvhArMBVhjUipfyzC7HqxybwIhAO3%2FACQh8hYR" +
-        "P9tBbyeKNThXR5x4t%2B4kWBWFM9o4pYhjKsUFCND%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQABoMMTY5OTQy" +
-        "MDIwNTIxIgy%2FRjW4UMixpIgXLyoqmQUlJi%2FBNQsLmcvzHsmKLGAkTSa%2B07rB3JADObNlS1F8ajKNef%2" +
-        "BHlGPmGtWr4TDVo%2BmfASgChgdwaZfZQ5%2BedFmO1O5mZIaaTXKpnpnggPEVv8EzFF4%2BuASmFhhD5GVEXi" +
-        "MHdMqXaYzeKpry2wjJFvvcUhLpwOq9MdGEOd9rJOWp3EwX35u6geuFlR36yHPqXZD8gEmOltWJXz64G8otbmxo" +
-        "imy9ZMjUe%2FT8KbAEg7WUfpHo23022myZjeUJYfk2X32mwQ%2F8FsUoU2pMQpTUHO0QmBlscMKzqlJMHalBzE" +
-        "ut%2Fuiw0jl%2BbbXmRcz6piW4DTHuK%2BQsRUNGAjItwaFxVjNemJ14m1yDSNEaRE1JdqWutAsdKQ87XgV%2F" +
-        "s9Td8KeFLJH%2FaC86ZXsgEjB2esnjp0q56ATBCs7yp9Im1966%2BoBOZaxqNAbtLwr%2F11YKn5V01R9uQpPi" +
-        "ieEKp7nipRbxajBB6bJcTen%2By6dvxGm%2FladwvUIH7BRWYPDCx1DA9s1bUEKpLg%2F2FSVEmhq6yjZV%2Bu" +
-        "eNkOBwqKwcLYKWgB3nfVYEu1ORzx6IMbVksnMJ%2BAlHrfj9HJF3XYDxca8yw%2F%2BIvi4oSK3j2Bc2bRyHim" +
-        "q9UCdkiQFFnyPzplZ8OVkZ0%2FfOnv0LkPYhkdiMUoPWIqPcOyjmSNjF%2FbqOs2O7cN8xUUy4Nv%2FhzUYaYZ" +
-        "svV6cy3Gk7DEq5Uj8eT5fEd3zlwLg0YKaG%2BEs2pHdoEIrDx6SgRDmZF5%2FlKwIEG8HrvkFLBvXxEjSnr%2F" +
-        "u0naENzYXIg9fgtc%2BtctfbNtD1jloLe0RelNMGWhP9huPN1kotv3AnJQ%2B4TCxhIbDQeJBox%2BpR7sSfso" +
-        "UfCAAgZr8ZzBlkhqAxYbAOCz3jhCPlLRdaGzD8v7GjBjqwAev5qyBqHCbUewXjxQs0JEOegwMO4gQ7IJt7OU0m" +
-        "l1%2F3gogILJ2hpX6SvPCIT5ECm0NR9gaO2Ej%2B1RSflO%2FwBMpo2p48rwUVnUZ2LwNnvGxf79BwbyMJ%2Bd" +
-        "cgaHQks4z5suSYJ4fabfQnYV32CwzEc%2FdNxaPKM7TFzaqaU%2FiVB91yVncr9sMp%2B8zKVMSyFBB32bQPYL" +
-        "7qZT33foMHOrQP3BCQjovrlGe67hOKURrh5lkf" +
-        "&X-Amz-SignedHeaders=host" +
-        "&response-content-disposition=inline%3Bfilename%3D%22companies_house_document.pdf%22" +
-        "&X-Amz-Signature=e18b2345566e0340bfc6ca7633939039df9fb71c1a44265701bb7102e42094c0";
 
     private static final URI EXPECTED_PRIVATE_DOCUMENT_URI;
     static {
@@ -102,7 +71,7 @@ class DocumentServiceIntegrationTest {
 
     @Test
     @DisplayName("getPrivateUri() gets the document private URI successfully")
-    void getPrivateUriGetsUriSuccessfully() throws  URISyntaxException {
+    void getPrivateUriGetsUriSuccessfully() {
 
         // Given
         givenSdkIsConfigured(environment, environmentVariables);

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceTest.java
@@ -1,0 +1,240 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.document.DocumentResourceHandler;
+import uk.gov.companieshouse.api.handler.document.request.DocumentGet;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.HttpStatus.FOUND;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.DOCUMENT_METADATA;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.EXPECTED_PRIVATE_DOCUMENT_URI;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.EXPECTED_PUBLIC_DOCUMENT_URI;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.PUBLIC_DOCUMENT_URI;
+
+/**
+ * Unit tests the {@link DocumentService} class.
+ */
+@ExtendWith(MockitoExtension.class)
+class DocumentServiceTest {
+
+    @InjectMocks
+    private DocumentService serviceUnderTest;
+
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private PublicToPrivateUriConverter converter;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private DocumentResourceHandler documentResourceHandler;
+
+    @Mock
+    private DocumentGet documentGet;
+
+    @Mock
+    private ApiResponse<Void> response;
+
+    @Mock
+    private Map<String, Object> headers;
+
+
+    @Test
+    void getPrivateUriGetsUriSuccessfully() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        givenResponseWithStatus(FOUND);
+        givenResponseContainsPublicUri(PUBLIC_DOCUMENT_URI);
+        when(converter.convertToPrivateUri(EXPECTED_PUBLIC_DOCUMENT_URI)).thenReturn(EXPECTED_PRIVATE_DOCUMENT_URI);
+
+        // When
+        final URI privateUri = serviceUnderTest.getPrivateUri(DOCUMENT_METADATA);
+
+        // Then
+        assertThat(privateUri, is(EXPECTED_PRIVATE_DOCUMENT_URI));
+    }
+
+    @Test
+    void getPublicUriGetsUriSuccessfully() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        givenResponseWithStatus(FOUND);
+        givenResponseContainsPublicUri(PUBLIC_DOCUMENT_URI);
+
+        // When
+        final URI publicUri = serviceUnderTest.getPublicUri(DOCUMENT_METADATA);
+
+        // Then
+        assertThat(publicUri, is(EXPECTED_PUBLIC_DOCUMENT_URI));
+    }
+
+    // TODO DCAC-71 Can we make the following error scenario behaviours ready for a consumer context?
+
+    @Test
+    void getPublicUriPropagatesApiClientServiceRuntimeException()  {
+
+        // Given
+        when(apiClientService.getApiClient())
+                .thenThrow(new RuntimeException("Environment variable missing: DOCUMENT_API_LOCAL_URL"));
+
+        // When
+        final RuntimeException exception =
+                assertThrows(RuntimeException.class,
+                        () -> serviceUnderTest.getPublicUri(DOCUMENT_METADATA));
+        assertThat(exception.getMessage(), is("Environment variable missing: DOCUMENT_API_LOCAL_URL"));
+    }
+
+    @Test
+    void getPublicUriErrorsForNon302Response() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        givenResponseWithStatus(NOT_FOUND);
+
+        // When
+        final RuntimeException exception =
+                assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getPublicUri(DOCUMENT_METADATA));
+        final var expectedError = "500 INTERNAL_SERVER_ERROR \"Received unexpected response status code " +
+                NOT_FOUND.value() + " getting public URI using document content request " +
+                DOCUMENT_METADATA + "/content.\"";
+        assertThat(exception.getMessage(), is(expectedError));
+    }
+
+    @Test
+    void getPublicUriErrorsForApiErrorResponseException() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        final var underlyingErrorMessage = "Unknown IO error.";
+        givenRequestExecutionException(
+                ApiErrorResponseException.fromIOException(new IOException(underlyingErrorMessage)));
+
+        // When and then
+        final RuntimeException exception =
+                assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getPublicUri(DOCUMENT_METADATA));
+        final var expectedError = "500 INTERNAL_SERVER_ERROR \"Caught ApiErrorResponseException with status code " +
+                INTERNAL_SERVER_ERROR.value() + ", and status message '" +  underlyingErrorMessage +
+                "' getting public URI using document content request " + DOCUMENT_METADATA + "/content.\"";
+        assertThat(exception.getMessage(), is(expectedError));
+    }
+
+    @Test
+    void getPublicUriErrorsForURIValidationException() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        final var underlyingErrorMessage = "URI pattern does not match expected URI pattern for this resource.";
+        givenRequestExecutionException(new URIValidationException(underlyingErrorMessage));
+
+        // When and then
+        final RuntimeException exception =
+                assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getPublicUri(DOCUMENT_METADATA));
+        final var expectedError = "500 INTERNAL_SERVER_ERROR \"Invalid URI " + DOCUMENT_METADATA +
+                "/content to get document public URI.\"";
+        assertThat(exception.getMessage(), is(expectedError));
+    }
+
+    @Test
+    void getPublicUriErrorsForURISyntaxException() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        final var corruptedLocationHeaderValue = "corrupted location?";
+        givenResponseWithStatus(FOUND);
+        givenResponseContainsPublicUri(corruptedLocationHeaderValue);
+
+        // When and then
+        final RuntimeException exception =
+                assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getPublicUri(DOCUMENT_METADATA));
+        final var expectedError = "500 INTERNAL_SERVER_ERROR \"Invalid URI `" + corruptedLocationHeaderValue +
+                "` obtained from Location header.\"";
+        assertThat(exception.getMessage(), is(expectedError));
+    }
+
+    @Test
+    void getPublicUriErrorsIntelligiblyForNullLocations() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        givenResponseWithStatus(FOUND);
+        when(response.getHeaders()).thenReturn(headers);
+        when(headers.get(LOCATION.toLowerCase())).thenReturn(null);
+
+        // When and then
+        final RuntimeException exception =
+                assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getPublicUri(DOCUMENT_METADATA));
+        final var expectedError = "500 INTERNAL_SERVER_ERROR \"No locations found in response from document API.\"";
+        assertThat(exception.getMessage(), is(expectedError));
+    }
+
+
+
+    @Test
+    void getPublicUriErrorsIntelligiblyForEmptyLocations() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        givenResponseWithStatus(FOUND);
+        when(response.getHeaders()).thenReturn(headers);
+        when(headers.get(LOCATION.toLowerCase())).thenReturn(new ArrayList<>());
+
+        // When and then
+        final RuntimeException exception =
+                assertThrows(ResponseStatusException.class,
+                        () -> serviceUnderTest.getPublicUri(DOCUMENT_METADATA));
+        final var expectedError = "500 INTERNAL_SERVER_ERROR \"No locations found in response from document API.\"";
+        assertThat(exception.getMessage(), is(expectedError));
+    }
+
+    private void givenRequestExecutionException(final Exception exception)
+            throws ApiErrorResponseException, URIValidationException {
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(apiClient.document()).thenReturn(documentResourceHandler);
+        when(documentResourceHandler.getDocument(DOCUMENT_METADATA + "/content")).thenReturn(documentGet);
+        when(documentGet.execute()).thenThrow(exception);
+    }
+
+    private void givenResponseWithStatus(final HttpStatus status)
+            throws ApiErrorResponseException, URIValidationException {
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(apiClient.document()).thenReturn(documentResourceHandler);
+        when(documentResourceHandler.getDocument(DOCUMENT_METADATA + "/content")).thenReturn(documentGet);
+        when(documentGet.execute()).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(status.value());
+    }
+
+    private void givenResponseContainsPublicUri(final String publicUri) {
+        when(response.getHeaders()).thenReturn(headers);
+        when(headers.get(LOCATION.toLowerCase())).thenReturn(List.of(publicUri));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -24,11 +25,11 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.api.model.filinghistory.FilingApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingLinks;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.ApiErrorResponsePayload;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Error;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.Arrays;
 
@@ -43,7 +44,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.DigitalCertifiedCopyProcessorApplication.NAMESPACE;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils.givenSdkIsConfigured;
 
 
@@ -51,7 +51,7 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils
  * Integration tests the {@link FilingHistoryDocumentService}.
  */
 @SpringBootTest
-@SpringJUnitConfig(FilingHistoryDocumentServiceIntegrationTest.Config.class)
+@SpringJUnitConfig(classes= {ApplicationConfiguration.class, FilingHistoryDocumentServiceIntegrationTest.Config.class})
 @AutoConfigureWireMock(port = 0)
 class FilingHistoryDocumentServiceIntegrationTest {
 
@@ -82,8 +82,13 @@ class FilingHistoryDocumentServiceIntegrationTest {
         }
 
         @Bean
-        Logger getLogger() {
-            return LoggerFactory.getLogger(NAMESPACE);
+        public RestTemplateBuilder getRestTemplateBuilder() {
+            return new RestTemplateBuilder();
+        }
+
+        @Bean
+        public PublicToPrivateUriConverter getPublicToPrivateUriConverter() {
+            return new PublicToPrivateUriConverter();
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -26,6 +25,7 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.api.model.filinghistory.FilingApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingLinks;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.ApiErrorResponsePayload;
@@ -51,7 +51,10 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils
  * Integration tests the {@link FilingHistoryDocumentService}.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes= {ApplicationConfiguration.class, FilingHistoryDocumentServiceIntegrationTest.Config.class})
+@SpringJUnitConfig(classes={
+        ApplicationConfiguration.class,
+        FilingHistoryDocumentServiceIntegrationTest.Config.class,
+        TestConfig.class})
 @AutoConfigureWireMock(port = 0)
 class FilingHistoryDocumentServiceIntegrationTest {
 
@@ -79,11 +82,6 @@ class FilingHistoryDocumentServiceIntegrationTest {
                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                     .setPropertyNamingStrategy(SNAKE_CASE)
                     .findAndRegisterModules();
-        }
-
-        @Bean
-        public RestTemplateBuilder getRestTemplateBuilder() {
-            return new RestTemplateBuilder();
         }
 
         @Bean

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
@@ -24,12 +24,13 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.api.model.filinghistory.FilingApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingLinks;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.ApiErrorResponsePayload;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Error;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.util.Arrays;
 
@@ -44,6 +45,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.DigitalCertifiedCopyProcessorApplication.NAMESPACE;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils.givenSdkIsConfigured;
 
 
@@ -51,10 +53,7 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils
  * Integration tests the {@link FilingHistoryDocumentService}.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes={
-        ApplicationConfiguration.class,
-        FilingHistoryDocumentServiceIntegrationTest.Config.class,
-        TestConfig.class})
+@SpringJUnitConfig(classes={FilingHistoryDocumentServiceIntegrationTest.Config.class, TestConfig.class})
 @AutoConfigureWireMock(port = 0)
 class FilingHistoryDocumentServiceIntegrationTest {
 
@@ -86,7 +85,12 @@ class FilingHistoryDocumentServiceIntegrationTest {
 
         @Bean
         public PublicToPrivateUriConverter getPublicToPrivateUriConverter() {
-            return new PublicToPrivateUriConverter();
+            return new PublicToPrivateUriConverter(getLogger());
+        }
+
+        @Bean
+        Logger getLogger() {
+            return LoggerFactory.getLogger(NAMESPACE);
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
@@ -1,0 +1,191 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static java.lang.System.getenv;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.is;
+import static software.amazon.awssdk.core.SdkSystemSetting.AWS_ACCESS_KEY_ID;
+import static software.amazon.awssdk.core.SdkSystemSetting.AWS_SECRET_ACCESS_KEY;
+import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
+
+/**
+ *  "Test" class re-purposed to execute {@link DocumentService#getPrivateUri(String)}
+ *  to get a private URl for a document in Cidev, and then verify that the URI can
+ *  be used to download the document. This is NOT to be run as part of an automated
+ *  test suite. It is for manual testing only.
+ */
+@SpringBootTest
+@SpringJUnitConfig(classes= {ApplicationConfiguration.class, GetDocumentApiPdfFromCidev.Config.class})
+@SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
+class GetDocumentApiPdfFromCidev {
+
+    private static final String DOCUMENT_METADATA = "/document/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0";
+
+    private static final URI EXPECTED_PRIVATE_DOCUMENT_URI;
+
+    static {
+        try {
+            EXPECTED_PRIVATE_DOCUMENT_URI = new URI(
+                 "s3://document-api-images-cidev/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf");
+        } catch (URISyntaxException e) {
+            // This will not happen
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final String DOWNLOADED_DOCUMENT_PATH = "./test/downloaded.pdf";
+
+
+    private static final String AWS_REGION_VALUE = "eu-west-2";
+
+    @Autowired
+    private DocumentService serviceUnderTest;
+
+    @Autowired
+    private Logger logger;
+
+    @Autowired
+    private S3Client s3Client;
+
+    @Configuration
+    @ComponentScan(basePackageClasses = GetDocumentApiPdfFromCidev.class)
+    static class Config {
+
+        @Bean
+        public S3Client s3Client() {
+            final var stsClient = StsClient.builder()
+                    .region(Region.of(AWS_REGION_VALUE))
+                    .build();
+            final var stsGetSessionTokenCredentialsProvider =
+                    StsGetSessionTokenCredentialsProvider.builder().
+                            stsClient(stsClient)
+                            .build();
+            return S3Client.builder().
+                    region(Region.of(AWS_REGION_VALUE)).
+                    credentialsProvider(stsGetSessionTokenCredentialsProvider)
+                    .build();
+        }
+
+    }
+
+    /**
+     * Required environment variables:
+     * <ul>
+     *     <li><code>BASIC_AUTH_CREDENTIALS</code></li>
+     *     <li><code>AWS_ACCESS_KEY_ID</code></li>
+     *     <li><code>AWS_SECRET_ACCESS_KEY</code></li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("get document PDF from cidev")
+    void getDocumentPdfFromCidev() throws URISyntaxException, IOException {
+
+        // Given
+        givenBasicAuthIsConfigured();
+        givenS3BucketAccessIsConfigured();
+
+        // When
+        final URI privateUri =
+                serviceUnderTest.getPrivateUri(DOCUMENT_METADATA);
+
+        copyInputStreamToFile(getInputStream(privateUri), new File(DOWNLOADED_DOCUMENT_PATH));
+
+        logger.info("Document PDF downloaded to " + DOWNLOADED_DOCUMENT_PATH);
+    }
+
+    /**
+     * Required environment variables:
+     * <ul>
+     *     <li><code>BASIC_AUTH_CREDENTIALS</code></li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("get private URI from cidev")
+    void getPrivateUriFromCidev() throws URISyntaxException {
+
+        // Given
+        givenBasicAuthIsConfigured();
+
+        // When
+        final URI privateUri =
+                serviceUnderTest.getPrivateUri(DOCUMENT_METADATA);
+
+        logger.info("Get private URI returned = " + privateUri);
+
+        // Then
+        assertThat(privateUri, is(EXPECTED_PRIVATE_DOCUMENT_URI));
+    }
+
+    /**
+     * Required environment variables:
+     * <ul>
+     *     <li><code>BASIC_AUTH_CREDENTIALS</code></li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("get public URI from cidev")
+    void getPublicUriFromCidev() {
+
+        // Given
+        givenBasicAuthIsConfigured();
+
+        // When
+        final URI publicUri =
+                serviceUnderTest.getPublicUri(DOCUMENT_METADATA);
+
+        logger.info("Get public URI returned = " + publicUri);
+
+        // Then
+        assertThat(publicUri.toString(), containsString(EXPECTED_PRIVATE_DOCUMENT_URI.getPath()));
+        assertThat(publicUri.getPath(), is(EXPECTED_PRIVATE_DOCUMENT_URI.getPath()));
+    }
+
+
+    private static void givenS3BucketAccessIsConfigured() {
+        assertThat(getenv(AWS_ACCESS_KEY_ID.environmentVariable()), not(is(emptyOrNullString())));
+        assertThat(getenv(AWS_SECRET_ACCESS_KEY.environmentVariable()), not(is(emptyOrNullString())));
+    }
+
+    private static void givenBasicAuthIsConfigured() {
+        // TODO DCAC-71 Constants, required env vars etc
+        assertThat(getenv("BASIC_AUTH_CREDENTIALS"), not(is(emptyOrNullString())));
+    }
+
+    private ResponseInputStream<GetObjectResponse> getInputStream(final URI privateUri) {
+        final var bucketName =  privateUri.getHost();
+        final var key = privateUri.getPath().substring(1); // remove leading /
+        final var getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+        return s3Client.getObject(getObjectRequest);
+    }
+
+}
+
+

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
@@ -23,7 +23,6 @@ import uk.gov.companieshouse.logging.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import static java.lang.System.getenv;
 import static org.hamcrest.CoreMatchers.not;
@@ -32,6 +31,8 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static software.amazon.awssdk.core.SdkSystemSetting.AWS_ACCESS_KEY_ID;
 import static software.amazon.awssdk.core.SdkSystemSetting.AWS_SECRET_ACCESS_KEY;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.DOCUMENT_METADATA;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.EXPECTED_PRIVATE_DOCUMENT_URI;
 import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
 
 /**
@@ -44,20 +45,6 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
 @SpringJUnitConfig(classes={GetDocumentApiPdfFromCidev.Config.class, TestConfig.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class GetDocumentApiPdfFromCidev {
-
-    private static final String DOCUMENT_METADATA = "/document/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0";
-
-    private static final URI EXPECTED_PRIVATE_DOCUMENT_URI;
-
-    static {
-        try {
-            EXPECTED_PRIVATE_DOCUMENT_URI = new URI(
-                 "s3://document-api-images-cidev/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf");
-        } catch (URISyntaxException e) {
-            // This will not happen
-            throw new RuntimeException(e);
-        }
-    }
 
     private static final String DOWNLOADED_DOCUMENT_PATH = "./test/downloaded.pdf";
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
@@ -194,6 +194,7 @@ class GetDocumentApiPdfFromCidev {
         assertThat(getenv("CHS_API_KEY"), not(is(emptyOrNullString())));
         variables.set("API_URL", "http://api.chs.local:4001");
         variables.set("PAYMENTS_API_URL", "http://api.chs.local:4001");
+        variables.set("DOCUMENT_API_LOCAL_URL", "http://document-api-cidev.aws.chdev.org");
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.io.File;
@@ -41,7 +42,7 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
  *  test suite. It is for manual testing only.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes= {ApplicationConfiguration.class, GetDocumentApiPdfFromCidev.Config.class})
+@SpringJUnitConfig(classes={ApplicationConfiguration.class, GetDocumentApiPdfFromCidev.Config.class, TestConfig.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class GetDocumentApiPdfFromCidev {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
@@ -17,7 +17,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -42,7 +41,7 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
  *  test suite. It is for manual testing only.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes={ApplicationConfiguration.class, GetDocumentApiPdfFromCidev.Config.class, TestConfig.class})
+@SpringJUnitConfig(classes={GetDocumentApiPdfFromCidev.Config.class, TestConfig.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class GetDocumentApiPdfFromCidev {
 
@@ -108,7 +107,7 @@ class GetDocumentApiPdfFromCidev {
      */
     @Test
     @DisplayName("get document PDF from cidev")
-    void getDocumentPdfFromCidev() throws URISyntaxException, IOException {
+    void getDocumentPdfFromCidev() throws IOException {
 
         // Given
         givenSdkIsConfiguredForTilt(environmentVariables);
@@ -131,7 +130,7 @@ class GetDocumentApiPdfFromCidev {
      */
     @Test
     @DisplayName("get private URI from cidev")
-    void getPrivateUriFromCidev() throws URISyntaxException {
+    void getPrivateUriFromCidev() {
 
         // Given
         givenSdkIsConfiguredForTilt(environmentVariables);

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentMetadataFromTilt.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentMetadataFromTilt.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -23,6 +25,7 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils
  *  an automated test suite. It is for manual testing only.
  */
 @SpringBootTest
+@SpringJUnitConfig(TestConfig.class)
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class GetDocumentMetadataFromTilt {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateDocumentService.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateDocumentService.java
@@ -18,7 +18,7 @@ import java.util.Collections;
 import static java.lang.System.getenv;
 
 /**
- * @Deprecated Use {@link DocumentService}.
+ * @deprecated Use {@link DocumentService}.
  */
 @Service
 public class RestTemplateDocumentService {

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateDocumentService.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateDocumentService.java
@@ -18,6 +18,8 @@ import java.util.Collections;
 import static java.lang.System.getenv;
 
 /**
+ * This provides a way of testing the sending of a document content request to the cidev document API without going
+ * via the Java SDKs only. It might be useful for troubleshooting.
  * @deprecated Use {@link DocumentService}.
  */
 @Service
@@ -37,7 +39,7 @@ public class RestTemplateDocumentService {
         this.converter = converter;
     }
 
-    public URI getPrivateUri(final String documentMetadata) throws URISyntaxException {
+    public URI getPrivateUri(final String documentMetadata) {
         final URI publicUri = getPublicUri(documentMetadata);
         return converter.convertToPrivateUri(publicUri);
     }
@@ -49,8 +51,6 @@ public class RestTemplateDocumentService {
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_PDF));
         final HttpEntity<String> httpEntity = new HttpEntity<>(null, headers);
 
-        // TODO DCAC-71 Configure doc api domain
-        // TODO DCAC-71 Structured logging
         final var message =
                 restTemplate.exchange(
                         "http://document-api-cidev.aws.chdev.org" + uri,
@@ -61,7 +61,6 @@ public class RestTemplateDocumentService {
     }
 
     private static String getBasicAuthCredentials() {
-        // TODO DCAC-71 Constants, required env vars etc
         return getenv("BASIC_AUTH_CREDENTIALS");
     }
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
@@ -15,7 +15,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.logging.Logger;
 
@@ -41,10 +40,7 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
  * @deprecated Use {@link GetDocumentApiPdfFromCidev}.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes={
-        ApplicationConfiguration.class,
-        RestTemplateGetDocumentApiPdfFromCidev.Config.class,
-        TestConfig.class})
+@SpringJUnitConfig(classes={RestTemplateGetDocumentApiPdfFromCidev.Config.class, TestConfig.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class RestTemplateGetDocumentApiPdfFromCidev {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.io.File;
@@ -37,10 +38,13 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
  *  to get a private URl for a document in Cidev, and then verify that the URI can
  *  be used to download the document. This is NOT to be run as part of an automated
  *  test suite. It is for manual testing only.
- * @Deprecated Use {@link GetDocumentApiPdfFromCidev}.
+ * @deprecated Use {@link GetDocumentApiPdfFromCidev}.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes= {ApplicationConfiguration.class, RestTemplateGetDocumentApiPdfFromCidev.Config.class})
+@SpringJUnitConfig(classes={
+        ApplicationConfiguration.class,
+        RestTemplateGetDocumentApiPdfFromCidev.Config.class,
+        TestConfig.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class RestTemplateGetDocumentApiPdfFromCidev {
 
@@ -171,7 +175,6 @@ class RestTemplateGetDocumentApiPdfFromCidev {
     }
 
     private static void givenBasicAuthIsConfigured() {
-        // TODO DCAC-71 Constants, required env vars etc
         assertThat(getenv("BASIC_AUTH_CREDENTIALS"), not(is(emptyOrNullString())));
     }
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
@@ -30,6 +30,8 @@ import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static software.amazon.awssdk.core.SdkSystemSetting.AWS_ACCESS_KEY_ID;
 import static software.amazon.awssdk.core.SdkSystemSetting.AWS_SECRET_ACCESS_KEY;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.DOCUMENT_METADATA;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.EXPECTED_PRIVATE_DOCUMENT_URI;
 import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
 
 /**
@@ -43,20 +45,6 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
 @SpringJUnitConfig(classes={RestTemplateGetDocumentApiPdfFromCidev.Config.class, TestConfig.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class RestTemplateGetDocumentApiPdfFromCidev {
-
-    private static final String DOCUMENT_METADATA = "/document/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0";
-
-    private static final URI EXPECTED_PRIVATE_DOCUMENT_URI;
-
-    static {
-        try {
-            EXPECTED_PRIVATE_DOCUMENT_URI = new URI(
-                 "s3://document-api-images-cidev/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf");
-        } catch (URISyntaxException e) {
-            // This will not happen
-            throw new RuntimeException(e);
-        }
-    }
 
     private static final String DOWNLOADED_DOCUMENT_PATH = "./test/downloaded.pdf";
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class Constants {
+
+    public static final String LOCATION =
+        "https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/" +
+        "docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf" +
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+        "&X-Amz-Credential=AWS_Access_Key_ID%2F20230523%2Feu-west-2%2Fs3%2Faws4_request" +
+        "&X-Amz-Date=20230523T071124Z" +
+        "&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEKf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2" +
+        "FwEaCWV1LXdlc3QtMiJIMEYCIQCkH0CgdgxtZUHzWSGqGZfvhArMBVhjUipfyzC7HqxybwIhAO3%2FACQh8hYR" +
+        "P9tBbyeKNThXR5x4t%2B4kWBWFM9o4pYhjKsUFCND%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQABoMMTY5OTQy" +
+        "MDIwNTIxIgy%2FRjW4UMixpIgXLyoqmQUlJi%2FBNQsLmcvzHsmKLGAkTSa%2B07rB3JADObNlS1F8ajKNef%2" +
+        "BHlGPmGtWr4TDVo%2BmfASgChgdwaZfZQ5%2BedFmO1O5mZIaaTXKpnpnggPEVv8EzFF4%2BuASmFhhD5GVEXi" +
+        "MHdMqXaYzeKpry2wjJFvvcUhLpwOq9MdGEOd9rJOWp3EwX35u6geuFlR36yHPqXZD8gEmOltWJXz64G8otbmxo" +
+        "imy9ZMjUe%2FT8KbAEg7WUfpHo23022myZjeUJYfk2X32mwQ%2F8FsUoU2pMQpTUHO0QmBlscMKzqlJMHalBzE" +
+        "ut%2Fuiw0jl%2BbbXmRcz6piW4DTHuK%2BQsRUNGAjItwaFxVjNemJ14m1yDSNEaRE1JdqWutAsdKQ87XgV%2F" +
+        "s9Td8KeFLJH%2FaC86ZXsgEjB2esnjp0q56ATBCs7yp9Im1966%2BoBOZaxqNAbtLwr%2F11YKn5V01R9uQpPi" +
+        "ieEKp7nipRbxajBB6bJcTen%2By6dvxGm%2FladwvUIH7BRWYPDCx1DA9s1bUEKpLg%2F2FSVEmhq6yjZV%2Bu" +
+        "eNkOBwqKwcLYKWgB3nfVYEu1ORzx6IMbVksnMJ%2BAlHrfj9HJF3XYDxca8yw%2F%2BIvi4oSK3j2Bc2bRyHim" +
+        "q9UCdkiQFFnyPzplZ8OVkZ0%2FfOnv0LkPYhkdiMUoPWIqPcOyjmSNjF%2FbqOs2O7cN8xUUy4Nv%2FhzUYaYZ" +
+        "svV6cy3Gk7DEq5Uj8eT5fEd3zlwLg0YKaG%2BEs2pHdoEIrDx6SgRDmZF5%2FlKwIEG8HrvkFLBvXxEjSnr%2F" +
+        "u0naENzYXIg9fgtc%2BtctfbNtD1jloLe0RelNMGWhP9huPN1kotv3AnJQ%2B4TCxhIbDQeJBox%2BpR7sSfso" +
+        "UfCAAgZr8ZzBlkhqAxYbAOCz3jhCPlLRdaGzD8v7GjBjqwAev5qyBqHCbUewXjxQs0JEOegwMO4gQ7IJt7OU0m" +
+        "l1%2F3gogILJ2hpX6SvPCIT5ECm0NR9gaO2Ej%2B1RSflO%2FwBMpo2p48rwUVnUZ2LwNnvGxf79BwbyMJ%2Bd" +
+        "cgaHQks4z5suSYJ4fabfQnYV32CwzEc%2FdNxaPKM7TFzaqaU%2FiVB91yVncr9sMp%2B8zKVMSyFBB32bQPYL" +
+        "7qZT33foMHOrQP3BCQjovrlGe67hOKURrh5lkf" +
+        "&X-Amz-SignedHeaders=host" +
+        "&response-content-disposition=inline%3Bfilename%3D%22companies_house_document.pdf%22" +
+        "&X-Amz-Signature=e18b2345566e0340bfc6ca7633939039df9fb71c1a44265701bb7102e42094c0";
+
+    public static final URI EXPECTED_PRIVATE_DOCUMENT_URI;
+    static {
+        try {
+            EXPECTED_PRIVATE_DOCUMENT_URI = new URI(
+                    "s3://document-api-images-cidev/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf");
+        } catch (URISyntaxException e) {
+            // This will not happen.
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
@@ -5,7 +5,9 @@ import java.net.URISyntaxException;
 
 public class Constants {
 
-    public static final String LOCATION =
+    public static final String DOCUMENT_METADATA = "/document/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0";
+
+    public static final String PUBLIC_DOCUMENT_URI =
         "https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/" +
         "docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf" +
         "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
@@ -33,9 +35,11 @@ public class Constants {
         "&response-content-disposition=inline%3Bfilename%3D%22companies_house_document.pdf%22" +
         "&X-Amz-Signature=e18b2345566e0340bfc6ca7633939039df9fb71c1a44265701bb7102e42094c0";
 
+    public static final URI EXPECTED_PUBLIC_DOCUMENT_URI;
     public static final URI EXPECTED_PRIVATE_DOCUMENT_URI;
     static {
         try {
+            EXPECTED_PUBLIC_DOCUMENT_URI = new URI(PUBLIC_DOCUMENT_URI);
             EXPECTED_PRIVATE_DOCUMENT_URI = new URI(
                     "s3://document-api-images-cidev/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf");
         } catch (URISyntaxException e) {

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/TestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/TestUtils.java
@@ -19,6 +19,7 @@ public class TestUtils {
         variables.set("CHS_API_KEY", "MGQ1MGNlYmFkYzkxZTM2MzlkNGVmMzg4ZjgxMmEz");
         variables.set("API_URL", "http://localhost:" + wireMockPort);
         variables.set("PAYMENTS_API_URL", "http://localhost:" + wireMockPort);
+        variables.set("DOCUMENT_API_LOCAL_URL", "http://localhost:" + wireMockPort);
         return wireMockPort;
     }
 
@@ -32,6 +33,7 @@ public class TestUtils {
         variables.set("CHS_API_KEY", "MGQ1MGNlYmFkYzkxZTM2MzlkNGVmMzg4ZjgxMmEz");
         variables.set("API_URL", "http://api.chs.local:4001");
         variables.set("PAYMENTS_API_URL", "http://api.chs.local:4001");
+        variables.set("DOCUMENT_API_LOCAL_URL", "http://document-api-cidev.aws.chdev.org");
     }
 
     /**
@@ -45,6 +47,7 @@ public class TestUtils {
         variables.set("CHS_API_KEY", "MGQ1MGNlYmFkYzkxZTM2MzlkNGVmMzg4ZjgxMmEz");
         variables.set("API_URL", "http://api.chs.local:4001");
         variables.set("PAYMENTS_API_URL", "http://api.chs.local:4001");
+        variables.set("DOCUMENT_API_LOCAL_URL", "http://document-api-cidev.aws.chdev.org");
         variableValues.forEach(variables::set);
     }
 


### PR DESCRIPTION
* Implementation of the request made from the `digital-certified-copy-processor` to get the short-lived public URI from the document API, and of its subsequent conversion to a long-lived private URI.
* All exceptions thrown made to be of either `RetryableException` type or `NonRetryableException` type for correct handling by the Kafka consumer the services and components will later operate within. The previously implemented `FilingHistoryDocumentService` has also been updated to throw these consumer-oriented exceptions.