### PR TITLE
DCAC-73: Produce to sign-digital-document

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@
 | Path                                              | Method | Description                                                         |
 |---------------------------------------------------|--------|---------------------------------------------------------------------|
 | *`/digital-certified-copy-processor/healthcheck`* | GET    | Returns HTTP OK (`200`) to indicate a healthy application instance. |
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # digital-certified-copy-processor
-Consumes messages from the `item-ordered-certified-copy` Kafka topic.
+
+* Consumes messages from the `item-ordered-certified-copy` Kafka topic.
+* Produces messages to the `sign-digital-document` Kafka topic.
 
 ## Environment variables
 
-| Name                      | Description                                  | Mandatory | Location                                |
-|---------------------------|----------------------------------------------|-----------|-----------------------------------------|
-| API_URL                   | URL to CHS API                               | ✓         | chs-configs repo environment global_env |
-| CHS_API_KEY               | API Access Key for CHS                       | ✓         | chs-configs repo environment global_env |
-| PAYMENTS_API_URL          | Payments API URL                             | ✓         | chs-configs repo environment global_env |
+| Name                        | Description                             | Mandatory | Location                                |
+|-----------------------------|-----------------------------------------|-----------|-----------------------------------------|
+| API_URL                     | URL to CHS API                          | ✓         | chs-configs repo environment global_env |
+| BOOTSTRAP_SERVER_URL        | URL(s) of Kafka cluster(s)              | ✓         | chs-configs repo environment env        |
+| CHS_API_KEY                 | API Access Key for CHS                  | ✓         | chs-configs repo environment global_env |
+| PAYMENTS_API_URL            | Payments API URL                        | ✓         | chs-configs repo environment global_env |
+| SIGN_DIGITAL_DOCUMENT_TOPIC | The topic this app produces messages to | ✓         | chs-configs repo environment env        |
 
 ## Endpoints
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
             <version>${system-rules.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <log4j.version>2.19.0</log4j.version>
 
         <!-- Structured logging -->
-        <structured-logging.version>1.9.22</structured-logging.version>
+        <structured-logging.version>1.9.25</structured-logging.version>
 
         <api-sdk-manager-java-library.version>1.0.7</api-sdk-manager-java-library.version>
         <re2j.version>1.7</re2j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <mockito-core.version>5.3.1</mockito-core.version>
         <software.amazon.awssdk.version>2.19.14</software.amazon.awssdk.version>
         <kafka-models.version>1.0.33</kafka-models.version>
+        <handlebars.version>4.3.1</handlebars.version>
     </properties>
 
     <dependencyManagement>
@@ -139,6 +140,18 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars</artifactId>
+            <version>${handlebars.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars-helpers</artifactId>
+            <version>${handlebars.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <system-rules.version>1.17.2</system-rules.version>
         <mockito-core.version>5.3.1</mockito-core.version>
         <software.amazon.awssdk.version>2.19.14</software.amazon.awssdk.version>
+        <kafka-models.version>1.0.33</kafka-models.version>
     </properties>
 
     <dependencyManagement>
@@ -85,6 +86,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>kafka-models</artifactId>
+            <version>${kafka-models.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/KafkaConfig.java
@@ -1,0 +1,43 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentAvroSerializer;
+import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, SignDigitalDocument> producerFactory(
+            @Value("${spring.kafka.bootstrap-servers}" ) final String bootstrapServers) {
+        final Map<String, Object> config = new HashMap<>();
+        config.put(
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, SignDigitalDocumentAvroSerializer.class);
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, SignDigitalDocument> kafkaTemplate(
+            @Value("${spring.kafka.bootstrap-servers}" ) final String bootstrapServers) {
+        return new KafkaTemplate<>(producerFactory(bootstrapServers));
+    }
+
+    @Bean
+    public SignDigitalDocumentAvroSerializer avroSerializer() {
+        return new SignDigitalDocumentAvroSerializer();
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesChecker.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesChecker.java
@@ -16,7 +16,9 @@ public class EnvironmentVariablesChecker {
         API_URL("API_URL"),
         PAYMENTS_API_URL("PAYMENTS_API_URL"),
         CHS_API_KEY("CHS_API_KEY"),
-        DOCUMENT_API_LOCAL_URL("DOCUMENT_API_LOCAL_URL");
+        DOCUMENT_API_LOCAL_URL("DOCUMENT_API_LOCAL_URL"),
+        BOOTSTRAP_SERVER_URL("BOOTSTRAP_SERVER_URL"),
+        SIGN_DIGITAL_DOCUMENT_TOPIC("SIGN_DIGITAL_DOCUMENT_TOPIC");
 
         private final String name;
 

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/kafka/SignDigitalDocumentAvroSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/kafka/SignDigitalDocumentAvroSerializer.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka;
+
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class SignDigitalDocumentAvroSerializer implements Serializer<SignDigitalDocument> {
+
+    @Override
+    public byte[] serialize(String topic, SignDigitalDocument data) {
+        final DatumWriter<SignDigitalDocument> datumWriter = new SpecificDatumWriter<>();
+
+        try (final var out = new ByteArrayOutputStream()) {
+            final var encoder = EncoderFactory.get().binaryEncoder(out, null);
+            datumWriter.setSchema(data.getSchema());
+            datumWriter.write(data, encoder);
+            encoder.flush();
+
+            byte[] serializedData = out.toByteArray();
+            encoder.flush();
+
+            return serializedData;
+        } catch (IOException e) {
+            throw new SerializationException("Error when serializing SignDigitalDocument to byte[]");
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/kafka/SignDigitalDocumentFactory.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/kafka/SignDigitalDocumentFactory.java
@@ -15,7 +15,7 @@ public class SignDigitalDocumentFactory {
         return SignDigitalDocument.newBuilder()
                 .setPrivateS3Location(privateUri.toString())
                 .setDocumentType(CERTIFIED_COPY_DOCUMENT_TYPE)
-                .setItemGroup(certifiedCopy.getGroupItem()) // TODO DCAC-73 Update SignDigitalDocument field name
+                .setItemGroup(certifiedCopy.getGroupItem())
                 .setOrderNumber(certifiedCopy.getOrderNumber())
                 .setCompanyName(certifiedCopy.getCompanyName())
                 .setCompanyNumber(certifiedCopy.getCompanyNumber())

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/kafka/SignDigitalDocumentFactory.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/kafka/SignDigitalDocumentFactory.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+import uk.gov.companieshouse.itemorderedcertifiedcopy.ItemOrderedCertifiedCopy;
+
+import java.net.URI;
+
+@Component
+public class SignDigitalDocumentFactory {
+
+    private static final String CERTIFIED_COPY_DOCUMENT_TYPE = "certified-copy";
+
+    public SignDigitalDocument buildMessage(final ItemOrderedCertifiedCopy certifiedCopy, final URI privateUri) {
+        return SignDigitalDocument.newBuilder()
+                .setPrivateS3Location(privateUri.toString())
+                .setDocumentType(CERTIFIED_COPY_DOCUMENT_TYPE)
+                .setItemGroup(certifiedCopy.getGroupItem()) // TODO DCAC-73 Update SignDigitalDocument field name
+                .setOrderNumber(certifiedCopy.getOrderNumber())
+                .setCompanyName(certifiedCopy.getCompanyName())
+                .setCompanyNumber(certifiedCopy.getCompanyNumber())
+                .setFilingHistoryDescription(certifiedCopy.getFilingHistoryDescription())
+                .setFilingHistoryType(certifiedCopy.getFilingHistoryType())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/KafkaProducerService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/KafkaProducerService.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentFactory;
+import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+import uk.gov.companieshouse.itemorderedcertifiedcopy.ItemOrderedCertifiedCopy;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.net.URI;
+
+@Service
+public class KafkaProducerService {
+
+    private final KafkaTemplate<String, SignDigitalDocument> kafkaTemplate;
+    private final Logger logger;
+    private final SignDigitalDocumentFactory signDigitalDocumentFactory;
+
+    private final String signDigitalDocumentTopic;
+
+    public KafkaProducerService(KafkaTemplate<String, SignDigitalDocument> kafkaTemplate,
+                                Logger logger,
+                                SignDigitalDocumentFactory signDigitalDocumentFactory,
+                                @Value("${kafka.topics.sign-digital-document}")
+                                String signDigitalDocumentTopic) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.logger = logger;
+        this.signDigitalDocumentFactory = signDigitalDocumentFactory;
+        this.signDigitalDocumentTopic = signDigitalDocumentTopic;
+    }
+
+    public void sendMessage(final ItemOrderedCertifiedCopy certifiedCopy, final URI privateUri) {
+
+        // TODO DCAC-73: Structured logging
+        logger.info("Sending a message for certified copy ID " + certifiedCopy.getItemId() +
+                        " from order " + certifiedCopy.getOrderNumber() + ".");
+        final var message = signDigitalDocumentFactory.buildMessage(certifiedCopy, privateUri);
+        final var future = kafkaTemplate.send(signDigitalDocumentTopic, message);
+        future.addCallback(new ListenableFutureCallback<>() {
+            @Override
+            public void onSuccess(SendResult<String, SignDigitalDocument> result) {
+                final var metadata =  result.getRecordMetadata();
+                final var partition = metadata.partition();
+                final var offset = metadata.offset();
+                // TODO DCAC-73: Structured logging
+                logger.info("Message " + message + " delivered to topic " + signDigitalDocumentTopic
+                                + " on partition " + partition + " with offset " + offset + ".");
+            }
+
+            @Override
+            public void onFailure(Throwable ex) {
+                // TODO DCAC-73: Structured logging
+                logger.error("Unable to deliver message " + message + ". Error: " + ex.getMessage() + ".");
+            }
+
+        });
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,6 @@ management.endpoints.web.path-mapping.health=healthcheck
 
 # Default application root path
 server.servlet.context-path=/digital-certified-copy-processor
+
+spring.kafka.bootstrap-servers=${BOOTSTRAP_SERVER_URL}
+kafka.topics.sign-digital-document=${SIGN_DIGITAL_DOCUMENT_TOPIC}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/DigitalCertifiedCopyProcessorApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/DigitalCertifiedCopyProcessorApplicationTests.java
@@ -3,10 +3,12 @@ package uk.gov.companieshouse.digitalcertifiedcopyprocessor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 
 @SpringBootTest
+@EmbeddedKafka
 @SpringJUnitConfig(TestConfig.class)
 class DigitalCertifiedCopyProcessorApplicationTests {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesCheckerTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesCheckerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 
@@ -21,6 +22,7 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.En
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.PAYMENTS_API_URL;
 
 @SpringBootTest
+@EmbeddedKafka
 @SpringJUnitConfig(TestConfig.class)
 class EnvironmentVariablesCheckerTest {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesCheckerTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/environment/EnvironmentVariablesCheckerTest.java
@@ -17,9 +17,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.API_URL;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.BOOTSTRAP_SERVER_URL;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.CHS_API_KEY;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.DOCUMENT_API_LOCAL_URL;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.PAYMENTS_API_URL;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker.RequiredEnvironmentVariables.SIGN_DIGITAL_DOCUMENT_TOPIC;
 
 @SpringBootTest
 @EmbeddedKafka
@@ -70,6 +72,19 @@ class EnvironmentVariablesCheckerTest {
     @Test
     void checkEnvironmentVariablesAllPresentReturnsFalseIfDocumentApiLocalUrlMissing() {
         populateAllVariablesExceptOneAndAssertSomethingMissing(DOCUMENT_API_LOCAL_URL);
+    }
+
+    @DisplayName("returns false if BOOTSTRAP_SERVER_URL is missing")
+    @Test
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfBootstrapServerUrlMissing() {
+        populateAllVariablesExceptOneAndAssertSomethingMissing(BOOTSTRAP_SERVER_URL);
+    }
+
+
+    @DisplayName("returns false if SIGN_DIGITAL_DOCUMENT_TOPIC is missing")
+    @Test
+    void checkEnvironmentVariablesAllPresentReturnsFalseIfSignDigitalDocumentTopicMissing() {
+        populateAllVariablesExceptOneAndAssertSomethingMissing(SIGN_DIGITAL_DOCUMENT_TOPIC);
     }
 
     private void populateAllVariablesExceptOneAndAssertSomethingMissing(

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/integration/SignDigitalDocumentInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/integration/SignDigitalDocumentInTiltProducer.java
@@ -1,0 +1,102 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.integration;
+
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.DOCUMENT;
+
+/**
+ * "Test" class re-purposed to produce {@link SignDigitalDocument} messages to the <code>sign-digital-document</code>
+ * topic in Tilt. This is NOT to be run as part of an automated test suite. It is for manual testing only.
+ */
+@SpringBootTest
+@ActiveProfiles("manual")
+@TestPropertySource(properties = "spring.kafka.bootstrap-servers=${KAFKA_IN_TILT_BOOTSTRAP_SERVER_URL}")
+@SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
+class SignDigitalDocumentInTiltProducer {
+
+    private static final String KAFKA_IN_TILT_BOOTSTRAP_SERVER_URL = "localhost:29092";
+    private static final String TOPIC_NAME_IN_TILT = "sign-digital-document";
+
+    public static class KafkaTemplateAvroSerializer implements Serializer<SignDigitalDocument> {
+
+        @Override
+        public byte[] serialize(String topic, SignDigitalDocument data) {
+            DatumWriter<SignDigitalDocument> datumWriter = new SpecificDatumWriter<>();
+
+            try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+                Encoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+                datumWriter.setSchema(data.getSchema());
+                datumWriter.write(data, encoder);
+                encoder.flush();
+
+                byte[] serializedData = out.toByteArray();
+                encoder.flush();
+
+                return serializedData;
+            } catch (IOException e) {
+                throw new SerializationException("Error when serializing ItemOrderedCertifiedCopy to byte[]");
+            }
+        }
+    }
+
+    @Configuration
+    @Profile("manual")
+    static class KafkaTemplateConfig {
+
+        @Bean
+        public ProducerFactory<String, SignDigitalDocument> producerFactory() {
+            Map<String, Object> config = new HashMap<>();
+            config.put(
+                    ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                    StringSerializer.class);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaTemplateAvroSerializer.class);
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_IN_TILT_BOOTSTRAP_SERVER_URL);
+            return new DefaultKafkaProducerFactory<>(config);
+        }
+
+        @Bean
+        public KafkaTemplate<String, SignDigitalDocument> kafkaTemplate() {
+            return new KafkaTemplate<>(producerFactory());
+        }
+
+        @Bean
+        public KafkaTemplateAvroSerializer avroSerializer() {
+            return new KafkaTemplateAvroSerializer();
+        }
+
+    }
+
+    @Autowired
+    private KafkaTemplate<String, SignDigitalDocument> testTemplate;
+
+    @SuppressWarnings("squid:S2699") // at least one assertion
+    @Test
+    void produceMessageToTilt() {
+        testTemplate.send(new ProducerRecord<>(TOPIC_NAME_IN_TILT, DOCUMENT));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import org.hamcrest.core.Is;
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +17,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.KafkaConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.RetryableException;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentFactory;
 
 import java.net.URI;
+import java.util.Arrays;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -60,6 +63,15 @@ class DocumentServiceIntegrationTest {
     @Configuration
     @ComponentScan(basePackageClasses = DocumentServiceIntegrationTest.class)
     static class Config { }
+
+    @AfterEach
+    void tearDown() {
+        final String[] AllEnvironmentVariableNames =
+                Arrays.stream(EnvironmentVariablesChecker.RequiredEnvironmentVariables.class.getEnumConstants())
+                        .map(Enum::name)
+                        .toArray(String[]::new);
+        environmentVariables.clear(AllEnvironmentVariableNames);
+    }
 
     @Test
     @DisplayName("getPrivateUri() gets the document private URI successfully")

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceIntegrationTest.java
@@ -14,8 +14,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.KafkaConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.RetryableException;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentFactory;
 
 import java.net.URI;
 
@@ -39,7 +41,10 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils
  * Integration tests the {@link DocumentService}.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes={DocumentServiceIntegrationTest.Config.class, TestConfig.class})
+@SpringJUnitConfig(classes={DocumentServiceIntegrationTest.Config.class,
+                            TestConfig.class,
+                            KafkaConfig.class,
+                            SignDigitalDocumentFactory.class})
 @AutoConfigureWireMock(port = 0)
 class DocumentServiceIntegrationTest {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
@@ -22,10 +22,12 @@ import org.springframework.core.env.Environment;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import uk.gov.companieshouse.api.model.filinghistory.FilingApi;
 import uk.gov.companieshouse.api.model.filinghistory.FilingLinks;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.KafkaConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.converter.PublicToPrivateUriConverter;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.RetryableException;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentFactory;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.ApiErrorResponsePayload;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Error;
 import uk.gov.companieshouse.logging.Logger;
@@ -51,7 +53,10 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils
  * Integration tests the {@link FilingHistoryDocumentService}.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes={FilingHistoryDocumentServiceIntegrationTest.Config.class, TestConfig.class})
+@SpringJUnitConfig(classes={FilingHistoryDocumentServiceIntegrationTest.Config.class,
+                            TestConfig.class,
+                            KafkaConfig.class,
+                            SignDigitalDocumentFactory.class})
 @AutoConfigureWireMock(port = 0)
 class FilingHistoryDocumentServiceIntegrationTest {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
@@ -17,7 +17,9 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.KafkaConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentFactory;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.io.File;
@@ -42,7 +44,11 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
  *  test suite. It is for manual testing only.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes={GetDocumentApiPdfFromCidev.Config.class, TestConfig.class})
+@SpringJUnitConfig(classes={
+        GetDocumentApiPdfFromCidev.Config.class,
+        TestConfig.class,
+        KafkaConfig.class,
+        SignDigitalDocumentFactory.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class GetDocumentApiPdfFromCidev {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentApiPdfFromCidev.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,6 +50,7 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
         TestConfig.class,
         KafkaConfig.class,
         SignDigitalDocumentFactory.class})
+@Tag("manual")
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class GetDocumentApiPdfFromCidev {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentMetadataFromTilt.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentMetadataFromTilt.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.environment.EnvironmentVariablesChecker;
 import uk.gov.companieshouse.logging.Logger;
@@ -25,7 +26,10 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils
  *  an automated test suite. It is for manual testing only.
  */
 @SpringBootTest
-@SpringJUnitConfig(TestConfig.class)
+@SpringJUnitConfig({FilingHistoryDocumentService.class,
+                    TestConfig.class,
+                    ApiClientService.class,
+                    ApplicationConfiguration.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class GetDocumentMetadataFromTilt {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentMetadataFromTilt.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/GetDocumentMetadataFromTilt.java
@@ -4,6 +4,7 @@ import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,6 +31,7 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.TestUtils
                     TestConfig.class,
                     ApiClientService.class,
                     ApplicationConfiguration.class})
+@Tag("manual")
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class GetDocumentMetadataFromTilt {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/KafkaProducerServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/KafkaProducerServiceIntegrationTest.java
@@ -1,0 +1,128 @@
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
+
+import consumer.deserialization.AvroDeserializer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.KafkaConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentFactory;
+import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.CERTIFIED_COPY;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.DOCUMENT;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.PRIVATE_DOCUMENT_URI;
+
+/**
+ * Integration tests the {@link KafkaProducerService}.
+ */
+@SpringBootTest
+@SpringJUnitConfig(classes={
+        ApplicationConfiguration.class,
+        TestConfig.class,
+        KafkaConfig.class,
+        KafkaProducerService.class,
+        SignDigitalDocumentFactory.class,
+        KafkaProducerServiceIntegrationTest.Config.class
+})
+@EmbeddedKafka
+class KafkaProducerServiceIntegrationTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("KafkaProducerServiceIntegrationTest");
+    private static final String SIGN_DIGITAL_DOCUMENT_TOPIC = "sign-digital-document";
+    private static final int MESSAGE_WAIT_TIMEOUT_SECONDS = 10;
+
+    private static final SignDigitalDocument EXPECTED_SIGN_DIGITAL_DOCUMENT_MESSAGE = DOCUMENT;
+
+    @Autowired
+    private KafkaProducerService serviceUnderTest;
+
+    private final CountDownLatch messageReceivedLatch = new CountDownLatch(1);
+    private SignDigitalDocument messageReceived;
+
+    @Configuration
+    static class Config {
+
+        @Bean
+        public ConsumerFactory<String, SignDigitalDocument> consumerFactory(
+                @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+            return new DefaultKafkaConsumerFactory<>(
+                    Map.of(
+                            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+                            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class,
+                            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class,
+                            ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class,
+                            ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, AvroDeserializer.class,
+                            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                            ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"),
+                    new StringDeserializer(),
+                    new ErrorHandlingDeserializer<>(new AvroDeserializer<>(SignDigitalDocument.class)));
+        }
+
+        @Bean
+        public ConcurrentKafkaListenerContainerFactory<String, SignDigitalDocument> kafkaListenerContainerFactory(
+                ConsumerFactory<String, SignDigitalDocument> consumerFactory) {
+            ConcurrentKafkaListenerContainerFactory<String, SignDigitalDocument> factory =
+                    new ConcurrentKafkaListenerContainerFactory<>();
+            factory.setConsumerFactory(consumerFactory);
+            factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+            return factory;
+        }
+
+    }
+
+    @Test
+    @DisplayName("KafkaProducerService produces a message to sign-digital-document successfully")
+    void producesMessageSuccessfully() throws InterruptedException {
+
+        serviceUnderTest.sendMessage(CERTIFIED_COPY, PRIVATE_DOCUMENT_URI);
+
+        verifyExpectedMessageIsReceived();
+    }
+
+    @KafkaListener(topics = SIGN_DIGITAL_DOCUMENT_TOPIC, groupId = "test-group")
+    public void receiveMessage(final @Payload SignDigitalDocument message) {
+        LOGGER.info("Received message: " + message);
+        messageReceived = message;
+        messageReceivedLatch.countDown();
+    }
+
+    private void verifyExpectedMessageIsReceived() throws InterruptedException {
+        verifyWhetherMessageIsReceived(true);
+        assertThat(messageReceived, is(notNullValue()));
+        assertThat(Objects.deepEquals(messageReceived, EXPECTED_SIGN_DIGITAL_DOCUMENT_MESSAGE), is(true));
+    }
+
+    private void verifyWhetherMessageIsReceived(final boolean messageIsReceived) throws InterruptedException {
+        LOGGER.info("Waiting to receive message for up to " + MESSAGE_WAIT_TIMEOUT_SECONDS + " seconds.");
+        final var received = messageReceivedLatch.await(MESSAGE_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertThat(received, is(messageIsReceived));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/KafkaProducerServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/KafkaProducerServiceIntegrationTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
@@ -36,7 +37,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.CERTIFIED_COPY;
-import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.DOCUMENT;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.PRIVATE_DOCUMENT_URI;
 
 /**
@@ -57,8 +57,16 @@ class KafkaProducerServiceIntegrationTest {
     private static final Logger LOGGER = LoggerFactory.getLogger("KafkaProducerServiceIntegrationTest");
     private static final String SIGN_DIGITAL_DOCUMENT_TOPIC = "sign-digital-document";
     private static final int MESSAGE_WAIT_TIMEOUT_SECONDS = 10;
-
-    private static final SignDigitalDocument EXPECTED_SIGN_DIGITAL_DOCUMENT_MESSAGE = DOCUMENT;
+    private static final SignDigitalDocument EXPECTED_SIGN_DIGITAL_DOCUMENT_MESSAGE = SignDigitalDocument.newBuilder()
+            .setOrderNumber(CERTIFIED_COPY.getOrderNumber())
+            .setPrivateS3Location(PRIVATE_DOCUMENT_URI.toString())
+            .setDocumentType("certified-copy")
+            .setItemGroup(CERTIFIED_COPY.getGroupItem())
+            .setCompanyName(CERTIFIED_COPY.getCompanyName())
+            .setCompanyNumber(CERTIFIED_COPY.getCompanyNumber())
+            .setFilingHistoryDescription(CERTIFIED_COPY.getFilingHistoryDescription())
+            .setFilingHistoryType(CERTIFIED_COPY.getFilingHistoryType())
+            .build();
 
     @Autowired
     private KafkaProducerService serviceUnderTest;
@@ -67,6 +75,7 @@ class KafkaProducerServiceIntegrationTest {
     private SignDigitalDocument messageReceived;
 
     @Configuration
+    @EnableKafka
     static class Config {
 
         @Bean

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/KafkaProducerServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/KafkaProducerServiceIntegrationTest.java
@@ -22,7 +22,6 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.ApplicationConfiguration;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.KafkaConfig;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentFactory;
 import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
 import uk.gov.companieshouse.logging.Logger;
@@ -45,7 +44,6 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants
 @SpringBootTest
 @SpringJUnitConfig(classes={
         ApplicationConfiguration.class,
-        TestConfig.class,
         KafkaConfig.class,
         KafkaProducerService.class,
         SignDigitalDocumentFactory.class,

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
@@ -15,13 +15,14 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsGetSessionTokenCredentialsProvider;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.KafkaConfig;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.config.TestConfig;
+import uk.gov.companieshouse.digitalcertifiedcopyprocessor.kafka.SignDigitalDocumentFactory;
 import uk.gov.companieshouse.logging.Logger;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import static java.lang.System.getenv;
 import static org.hamcrest.CoreMatchers.not;
@@ -42,7 +43,11 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
  * @deprecated Use {@link GetDocumentApiPdfFromCidev}.
  */
 @SpringBootTest
-@SpringJUnitConfig(classes={RestTemplateGetDocumentApiPdfFromCidev.Config.class, TestConfig.class})
+@SpringJUnitConfig(classes={
+        RestTemplateGetDocumentApiPdfFromCidev.Config.class,
+        KafkaConfig.class,
+        TestConfig.class,
+        SignDigitalDocumentFactory.class})
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class RestTemplateGetDocumentApiPdfFromCidev {
 
@@ -91,7 +96,7 @@ class RestTemplateGetDocumentApiPdfFromCidev {
      */
     @Test
     @DisplayName("get document PDF from cidev")
-    void getDocumentPdfFromCidev() throws URISyntaxException, IOException {
+    void getDocumentPdfFromCidev() throws IOException {
 
         // Given
         givenBasicAuthIsConfigured();
@@ -114,7 +119,7 @@ class RestTemplateGetDocumentApiPdfFromCidev {
      */
     @Test
     @DisplayName("get private URI from cidev")
-    void getPrivateUriFromCidev() throws URISyntaxException {
+    void getPrivateUriFromCidev() {
 
         // Given
         givenBasicAuthIsConfigured();

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/RestTemplateGetDocumentApiPdfFromCidev.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,6 +49,7 @@ import static wiremock.org.apache.commons.io.FileUtils.copyInputStreamToFile;
         KafkaConfig.class,
         TestConfig.class,
         SignDigitalDocumentFactory.class})
+@Tag("manual")
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class RestTemplateGetDocumentApiPdfFromCidev {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/SignDigitalDocumentInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/SignDigitalDocumentInTiltProducer.java
@@ -9,6 +9,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,8 +35,9 @@ import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants
  * topic in Tilt. This is NOT to be run as part of an automated test suite. It is for manual testing only.
  */
 @SpringBootTest
-@ActiveProfiles("manual")
 @TestPropertySource(properties = "spring.kafka.bootstrap-servers=${KAFKA_IN_TILT_BOOTSTRAP_SERVER_URL}")
+@ActiveProfiles("manual")
+@Tag("manual")
 @SuppressWarnings("squid:S3577") // This is NOT to be run as part of an automated test suite.
 class SignDigitalDocumentInTiltProducer {
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/SignDigitalDocumentInTiltProducer.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/SignDigitalDocumentInTiltProducer.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.digitalcertifiedcopyprocessor.integration;
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
 
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.util;
 
+import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -47,5 +49,17 @@ public class Constants {
             throw new RuntimeException(e);
         }
     }
+
+    public static final SignDigitalDocument DOCUMENT = SignDigitalDocument.newBuilder()
+            .setOrderNumber("ORD-152416-079544")
+            .setPrivateS3Location("s3://document-api-images-cidev/docs/--EdB7fbldt5oujK6Nz7jZ3hGj_x6vW8Q_2gQTyjWBM/application-pdf")
+            .setDocumentType("363s")
+            .setItemGroup("ORD-152416-079544-1")
+            .setCompanyName("Test Company")
+            .setCompanyNumber("00000000")
+            .setFilingHistoryDescription("A test filing history document")
+            .setFilingHistoryType("AM01")
+            .build();
+
 
 }

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
@@ -1,9 +1,11 @@
 package uk.gov.companieshouse.digitalcertifiedcopyprocessor.util;
 
 import uk.gov.companieshouse.documentsigning.SignDigitalDocument;
+import uk.gov.companieshouse.itemorderedcertifiedcopy.ItemOrderedCertifiedCopy;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 public class Constants {
 
@@ -39,11 +41,13 @@ public class Constants {
 
     public static final URI EXPECTED_PUBLIC_DOCUMENT_URI;
     public static final URI EXPECTED_PRIVATE_DOCUMENT_URI;
+    public static final URI PRIVATE_DOCUMENT_URI;
     static {
         try {
             EXPECTED_PUBLIC_DOCUMENT_URI = new URI(PUBLIC_DOCUMENT_URI);
             EXPECTED_PRIVATE_DOCUMENT_URI = new URI(
                     "s3://document-api-images-cidev/docs/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0/application-pdf");
+            PRIVATE_DOCUMENT_URI = EXPECTED_PRIVATE_DOCUMENT_URI;
         } catch (URISyntaxException e) {
             // This will not happen.
             throw new RuntimeException(e);
@@ -59,6 +63,20 @@ public class Constants {
             .setCompanyNumber("00000000")
             .setFilingHistoryDescription("A test filing history document")
             .setFilingHistoryType("AM01")
+            .build();
+
+    public static final ItemOrderedCertifiedCopy CERTIFIED_COPY = ItemOrderedCertifiedCopy.newBuilder()
+            .setOrderNumber("ORD-152416-079544")
+            .setItemId("CCD-768116-517930")
+            .setGroupItem("/item-groups/IG-000216-873460/items/CCD-768116-517930")
+            .setCompanyName("Test Company Limited")
+            .setCompanyNumber("00006400")
+            .setFilingHistoryDescription("appoint-person-director-company-with-name-date")
+            .setFilingHistoryId("OTYyMTM3NjgxOGFkaXF6a2N4")
+            .setFilingHistoryType("AP01")
+            .setFilingHistoryDescriptionValues(Map.of(
+                    "appointment_date", "2023-05-01",
+                    "officer_name", "Mr Tom Sunburn"))
             .build();
 
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,9 +1,2 @@
-# Actuator health check config
-management.endpoints.web.base-path=/
-management.endpoints.web.path-mapping.health=healthcheck
-
-# Default application root path
-server.servlet.context-path=/digital-certified-copy-processor
-
 spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
 kafka.topics.sign-digital-document=sign-digital-document

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,9 @@
+# Actuator health check config
+management.endpoints.web.base-path=/
+management.endpoints.web.path-mapping.health=healthcheck
+
+# Default application root path
+server.servlet.context-path=/digital-certified-copy-processor
+
+spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
+kafka.topics.sign-digital-document=sign-digital-document


### PR DESCRIPTION
* Use KafkaTemplate to produce message to the `sign-digital-document` topic.
* Add tests.
* Bring in handlebars packages for integration tests.
* Sync up manual and integration tests with changes to application Spring bean context.