### PR TITLE
DCAC-69: Provide a minimal KafkaService implementation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/NullService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/NullService.java
@@ -1,12 +1,13 @@
-package uk.gov.companieshouse.digitalcertifiedcopyprocessor.consumer;
+package uk.gov.companieshouse.digitalcertifiedcopyprocessor.service;
 
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.NonRetryableException;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.service.KafkaService;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.service.KafkaServiceParameters;
 
+/**
+ * The default service.
+ */
 @Component
-public class NonRetryableExceptionService implements KafkaService {
+class NullService implements KafkaService {
 
     @Override
     public void processMessage(KafkaServiceParameters parameters) {

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/TestConfig.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/config/TestConfig.java
@@ -13,12 +13,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.web.client.RestTemplate;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.consumer.NonRetryableExceptionService;
-import uk.gov.companieshouse.digitalcertifiedcopyprocessor.service.KafkaService;
 import uk.gov.companieshouse.itemorderedcertifiedcopy.ItemOrderedCertifiedCopy;
 import uk.gov.companieshouse.kafka.exceptions.SerializationException;
 import uk.gov.companieshouse.kafka.serialization.SerializerFactory;
@@ -79,9 +76,4 @@ public class TestConfig {
                 });
     }
 
-    @Bean
-    @Primary
-    public KafkaService getService() {
-        return new NonRetryableExceptionService();
-    }
 }


### PR DESCRIPTION
* This should allow the app to start up and consume `item-ordered-certified-copy` messages.