### PR TITLE
add method to strip path from documentmetadata

### DIFF
--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentService.java
@@ -12,7 +12,6 @@ import uk.gov.companieshouse.digitalcertifiedcopyprocessor.exception.RetryableEx
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.util.DataMap;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -52,13 +51,15 @@ public class DocumentService {
         return privateUri;
     }
 
-    private String convertDocumentMetadata(String documentMetadata){
-        /* Because filing history returns the document metadata as a full URL including the hostname, 
-           we need to extract just the path from it. */
+    /**
+     * Because filing history returns the document metadata as a full URL including the hostname,
+     * we need to extract just the path from it.
+     */
+    private String stripHostnameFromDocumentMetadata(String documentMetadata) {
         try {
             URL documentURL = new URL(documentMetadata);
-            logger.debug("Stripping path " + documentURL.getPath() +" from full URL: " + documentMetadata,
-                getLogMap(documentMetadata));
+            logger.debug("Stripping path " + documentURL.getPath() + " from full URL: " + documentMetadata,
+                    getLogMap(documentMetadata));
             return documentURL.getPath();
         } catch (Exception e) {
             logger.info("No valid URL provided in documentMetadata, assuming only path provided.");
@@ -67,7 +68,7 @@ public class DocumentService {
     }
 
     public URI getPublicUri(final String documentMetadata) {
-        final var uri = GET_DOCUMENT_CONTENT_URL.expand(convertDocumentMetadata(documentMetadata)).toString();
+        final var uri = GET_DOCUMENT_CONTENT_URL.expand(stripHostnameFromDocumentMetadata(documentMetadata)).toString();
         try {
             final var response = getDocumentContent(uri, documentMetadata);
             return getFirstLocationAsUri(response, documentMetadata);

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/DocumentServiceTest.java
@@ -33,6 +33,7 @@ import static org.springframework.http.HttpStatus.FOUND;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.DOCUMENT_METADATA;
+import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.DOCUMENT_METADATA_WITH_HOSTNAME;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.EXPECTED_PRIVATE_DOCUMENT_URI;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.EXPECTED_PUBLIC_DOCUMENT_URI;
 import static uk.gov.companieshouse.digitalcertifiedcopyprocessor.util.Constants.PUBLIC_DOCUMENT_URI;
@@ -102,6 +103,20 @@ class DocumentServiceTest {
         assertThat(publicUri, is(EXPECTED_PUBLIC_DOCUMENT_URI));
     }
 
+    @Test
+    @DisplayName("getPublicUri() gets URI successfully when document metadata contains a hostname prefix")
+    void getPublicUriGetsUriSuccessfullyWithHost() throws ApiErrorResponseException, URIValidationException {
+
+        // Given
+        givenResponseWithStatus(FOUND);
+        givenResponseContainsPublicUri(PUBLIC_DOCUMENT_URI);
+
+        // When
+        final URI publicUri = serviceUnderTest.getPublicUri(DOCUMENT_METADATA_WITH_HOSTNAME);
+
+        // Then
+        assertThat(publicUri, is(EXPECTED_PUBLIC_DOCUMENT_URI));
+    }
     @Test
     @DisplayName(
             "getPublicUri() propagates a RuntimeException from the ApiClientService wrapped as a NonRetryableException")

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/util/Constants.java
@@ -10,6 +10,8 @@ import java.util.Map;
 public class Constants {
 
     public static final String DOCUMENT_METADATA = "/document/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0";
+    public static final String DOCUMENT_METADATA_WITH_HOSTNAME =
+            "http://document-api-cidev.aws.chdev.org/document/-fsWaC-ED30jRNACt2dqNYc-lH2uODjjLhliYjryjV0";
 
     public static final String PUBLIC_DOCUMENT_URI =
         "https://document-api-images-cidev.s3.eu-west-2.amazonaws.com/" +


### PR DESCRIPTION
Currently, in cidev the call to get the filing history's document metadata returns a full URL including the hostname.

Due to this being existing behaviour that hasn't been altered in 8+ years, this solution strips the hostname from the provided document metadata, so that it can be used in the standard path only way the api-sdk-java operates. 