### PR TITLE
GCI-2518: Refactor error logging to capture underlying cause without a stacktrace

### DIFF
--- a/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentService.java
+++ b/src/main/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentService.java
@@ -80,14 +80,14 @@ public class FilingHistoryDocumentService {
                                                      final String filingHistoryDocumentId,
                                                      final String uri) {
         final RetryableException propagatedException;
-        final HttpStatus status = HttpStatus.valueOf(apiException.getStatusCode());
+        final var status = HttpStatus.valueOf(apiException.getStatusCode());
         if (status.is5xxServerError()) {
-            final String error = "Error sending request to "
+            final var error = "Error sending request to "
                     + client.getBasePath() + uri + ": " + apiException.getStatusMessage();
             logger.error(error, getLogMap(companyNumber, filingHistoryDocumentId, status, error));
             propagatedException = new RetryableException(error);
         } else {
-            final String error = "Error getting filing history document " + filingHistoryDocumentId +
+            final var error = "Error getting filing history document " + filingHistoryDocumentId +
                     " for company number " + companyNumber + ": " + apiException.getMessage();
             logger.error(error, getLogMap(companyNumber, filingHistoryDocumentId, status, error));
             propagatedException =  new RetryableException(error);

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceIntegrationTest.java
@@ -161,7 +161,8 @@ class FilingHistoryDocumentServiceIntegrationTest {
                 assertThrows(RetryableException.class,
                         () -> serviceUnderTest.getDocumentMetadata(UNKNOWN_COMPANY_NUMBER, ID_1));
         final String expectedReason = "Error getting filing history document " + ID_1 +
-                " for company number " + UNKNOWN_COMPANY_NUMBER + ".";
+                " for company number " + UNKNOWN_COMPANY_NUMBER +
+            ": 400 Bad Request\n{\"errors\":[{\"type\":\"ch:service\",\"error\":\"filing-history-item-not-found\"}]}";
         assertThat(exception.getMessage(), Is.is(expectedReason));
     }
 
@@ -180,7 +181,8 @@ class FilingHistoryDocumentServiceIntegrationTest {
                 assertThrows(RetryableException.class,
                         () -> serviceUnderTest.getDocumentMetadata(COMPANY_NUMBER, UNKNOWN_ID));
         final String expectedReason = "Error getting filing history document " + UNKNOWN_ID +
-                " for company number " + COMPANY_NUMBER + ".";
+                " for company number " + COMPANY_NUMBER +
+            ": 400 Bad Request\n{\"errors\":[{\"type\":\"ch:service\",\"error\":\"filing-history-item-not-found\"}]}";
         assertThat(exception.getMessage(), is(expectedReason));
     }
 

--- a/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/digitalcertifiedcopyprocessor/service/FilingHistoryDocumentServiceTest.java
@@ -45,7 +45,7 @@ class FilingHistoryDocumentServiceTest {
             "Error sending request to http://host/company/00006400/filing-history/1: " + IOEXCEPTION_MESSAGE;
 
     private static final String NOT_FOUND_EXPECTED_REASON = "Error getting filing history document 1 for company number "
-            + COMPANY_NUMBER + ".";
+            + COMPANY_NUMBER + ": 404 Not Found";
 
     private static final String FILING_SOUGHT = "1";
 


### PR DESCRIPTION
* Replaced unnecessary stack trace log with logging of the underlying cause only, providing the required info only.